### PR TITLE
Extract workbench styles

### DIFF
--- a/Buffaly.Ontology.Portal/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
+++ b/Buffaly.Ontology.Portal/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
@@ -1,6 +1,13 @@
 <%using Simple.ks.html%>
 <%using ProtoScript.Workbench.Controls.ks.html%>
 
+<%redefinefunction SimplePage.Head
+{
+        (returnex{%>
+<link rel="stylesheet" href="/css/protoscript-workbench.css" />
+        <%})
+}%>
+
 <%redefinefunction SimplePage.Title
 {
 	(return "Ontology - ProtoScript")
@@ -36,18 +43,7 @@
 
 	(returnex{%>
 
-<style type="text/css">
-	.content-page {
-		background-color: white;
-		margin-left: 0px;
-	}
-	#sidebar {
-		display: none;
-	}
-	#divPageTitle {
-		display: none;
-	}
-</style>
+
 
 <div class="row g-3" id="divDirective">
     <div class="col-lg-9 border">
@@ -62,7 +58,7 @@
                     <i class="bi bi-save"></i> Save
                 </button>
             </div>
-            <textarea id="txtCode" kcs:FieldName="Directive" class="form-control no-autosize" style="width: 100%; min-height:600px; white-space:pre;"></textarea>
+            <textarea id="txtCode" kcs:FieldName="Directive" class="form-control no-autosize code-area"></textarea>
             <div id="divOffset"></div>
             <div id="divDescription"></div>
             <div id="divPredictions" class="text-pre"></div>
@@ -82,7 +78,7 @@
         <%SimplePage.GetTabs(oTopTabs)%>
     </div>
     <div class="col-lg-3 border">
-        <div id="divSymbolContainer" class="position-fixed" style="z-index: 100; height: 80vh; overflow: scroll;">
+        <div id="divSymbolContainer" class="position-fixed symbol-container">
             <%oProject.Content{%>
             <div class="mb-2">
                 <div class="input-group">
@@ -158,39 +154,7 @@
 <script type="text/javascript" src="/js/protoscript-workbench.js"></script>
 
 
-<style type="text/css">
-	.CodeMirror {
-		border: 1px solid #eee;
-		height: auto;
-	}
 
-	.loading {
-		position: relative;
-	}
-
-		.loading::after {
-			content: '';
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			width: 32px;
-			height: 32px;
-			margin-top: -16px;
-			margin-left: -16px;
-			border: 4px solid #ccc;
-			border-top-color: #333;
-			border-radius: 50%;
-			animation: spin 0.8s infinite linear;
-			z-index: 9999;
-		}
-
-	@keyframes spin {
-		to {
-			transform: rotate(360deg);
-		}
-	}
-
-</style>
 
 
 
@@ -584,53 +548,6 @@
 			}
 		}));
 </script>
-<style type="text/css">
-	.found-text-marker {
-		background-color:cornflowerblue;
-	}
-	.debug-break-marker {
-		background-color: yellow;
-	}
-.error-marker {
-  color: black;
-  width: 12px !important;
-  height: 12px;
-  background-color: #ff4d4d; /* Slightly softer red */
-  border-radius: 50%; /* Circular error indicator */
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
-}
-
-.error-marker .error-message {
-  display: none;
-  position: absolute;
-  white-space: pre-wrap; /* Preserve whitespace and allow wrapping if needed */
-  background-color: #fff; /* Fully opaque background */
-  color: #212529; /* Dark text for readability */
-  border: 1px solid #999;
-  padding: 10px 16px; /* More padding, especially on the left */
-  left: 50px; /* Move tooltip further right */
-  top: -1.5em;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3); /* Stronger shadow for visibility */
-  font-size: 14px;
-  font-weight: 500;
-  z-index: 9999; /* Higher z-index to keep it above everything */
-  opacity: 1;
-  border-radius: 4px; /* Soft edges */
-  max-width: none; /* Prevent unwanted width constraints */
-  width: 500px; /* Allow width to expand naturally */
-  min-width: fit-content; /* Ensures small messages aren't too narrow */
-}
-
-.error-marker:hover .error-message {
-  display: block;
-}
-
-
-      .breakpoints {width: .8em;}
-      .breakpoint { color: #822; font-size: x-large; padding-top: 0px; margin-top : -5px; }
-</style>
 	<%})
 }%>
 

--- a/Buffaly.Ontology.Portal/wwwroot/css/protoscript-workbench.css
+++ b/Buffaly.Ontology.Portal/wwwroot/css/protoscript-workbench.css
@@ -1,0 +1,92 @@
+/* Styles for ProtoScript Workbench */
+.content-page {
+    background-color: white;
+    margin-left: 0px;
+}
+#sidebar {
+    display: none;
+}
+#divPageTitle {
+    display: none;
+}
+
+.CodeMirror {
+    border: 1px solid #eee;
+    height: auto;
+}
+.loading {
+    position: relative;
+}
+.loading::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 32px;
+    height: 32px;
+    margin-top: -16px;
+    margin-left: -16px;
+    border: 4px solid #ccc;
+    border-top-color: #333;
+    border-radius: 50%;
+    animation: spin 0.8s infinite linear;
+    z-index: 9999;
+}
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.found-text-marker {
+    background-color: cornflowerblue;
+}
+.debug-break-marker {
+    background-color: yellow;
+}
+.error-marker {
+  color: black;
+  width: 12px !important;
+  height: 12px;
+  background-color: #ff4d4d;
+  border-radius: 50%;
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+}
+.error-marker .error-message {
+  display: none;
+  position: absolute;
+  white-space: pre-wrap;
+  background-color: #fff;
+  color: #212529;
+  border: 1px solid #999;
+  padding: 10px 16px;
+  left: 50px;
+  top: -1.5em;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 9999;
+  opacity: 1;
+  border-radius: 4px;
+  max-width: none;
+  width: 500px;
+  min-width: fit-content;
+}
+.error-marker:hover .error-message {
+  display: block;
+}
+.breakpoints { width: .8em; }
+.breakpoint { color: #822; font-size: x-large; padding-top: 0px; margin-top: -5px; }
+
+.code-area {
+    width: 100%;
+    min-height: 600px;
+    white-space: pre;
+}
+.symbol-container {
+    z-index: 100;
+    height: 80vh;
+    overflow: scroll;
+}


### PR DESCRIPTION
## Summary
- consolidate ProtoScript.Workbench styles into `wwwroot/css/protoscript-workbench.css`
- add head link to new stylesheet
- replace inline styles with CSS classes

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a51060fe4832dade12c3a0ef6947e