### PR TITLE
Remove unused iLength variable

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/js/protoscript-workbench.js
+++ b/Buffaly.Ontology.Portal/wwwroot/js/protoscript-workbench.js
@@ -600,7 +600,6 @@ function OnFilterSymbols() {
 
 
 ////////////////////////////Extensions//////////////////
-var iLength = 0;
 
 function countCR(sTxt, iOffset) {
 	var iCount = 0;


### PR DESCRIPTION
## Summary
- clean up unused variable in protoscript workbench JS

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a51d2a634832d9de99fac3fe2eb0c