### PR TITLE
Fix symbol filter event handling

### DIFF
--- a/Buffaly.Ontology.Portal/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
+++ b/Buffaly.Ontology.Portal/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
@@ -103,7 +103,7 @@
                     <span class="input-group-text">
                         <i class="bi bi-search"></i>
                     </span>
-                    <input type="text" id="txtSymbolSearch" class="form-control" placeholder="Search symbols..." onkeyup="OnFilterSymbols()" />
+                    <input type="text" id="txtSymbolSearch" class="form-control" placeholder="Search symbols..." onkeyup="OnFilterSymbols(event)" />
                 </div>
             </div>
 

--- a/Buffaly.Ontology.Portal/wwwroot/js/protoscript-workbench.js
+++ b/Buffaly.Ontology.Portal/wwwroot/js/protoscript-workbench.js
@@ -38,10 +38,10 @@ Page.AddOnLoad(async function () {
 			OnSaveCurrentFile();
 			event.preventDefault();
 		}
-		else if (event.ctrlKey && event.key == ',') {
-			event.preventDefault();
-			OnStartSymbolSearch();
-		}
+                else if (event.ctrlKey && event.key == ',') {
+                        event.preventDefault();
+                        OnStartSymbolSearch(event);
+                }
 		else if (event.ctrlKey && event.key == 'b') {
 			event.preventDefault();
 			CompileCode();
@@ -535,7 +535,7 @@ function OnNavigateToSelectedProjectFile() {
 }
 
 
-async function OnStartSymbolSearch() {
+async function OnStartSymbolSearch(evt) {
 	ShowTab("tab-symbols");
 	ControlUtil.SetValue("txtSymbolSearch", "");
 
@@ -543,7 +543,7 @@ async function OnStartSymbolSearch() {
 		await CompileCode()
 	}
 
-	OnFilterSymbols();
+        OnFilterSymbols(evt);
 	_$("txtSymbolSearch").scrollIntoView(false)
 	_$("txtSymbolSearch").focus();
 }
@@ -575,9 +575,9 @@ function OnNavigateToSelectedSymbol() {
 	}
 }
 
-function OnFilterSymbols() {
-	//(function () {
-	if (window.event.code != "ArrowDown" && window.event.code != "ArrowUp") {
+function OnFilterSymbols(evt) {
+        //(function () {
+        if (!evt || (evt.code != "ArrowDown" && evt.code != "ArrowUp")) {
 		var sSearch = ControlUtil.GetValue("txtSymbolSearch");
 		if (StringUtil.IsEmpty(sSearch))
 			OnBindFileSymbols();


### PR DESCRIPTION
## Summary
- pass the keyboard event through `OnFilterSymbols`
- adjust `OnStartSymbolSearch` and HTML handlers to forward the event

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a51d4b81c832d80c1fb8cbda52e2d