### PR TITLE
Improve method resolution strategy

### DIFF
--- a/Ontology.Tests/ReflectionUtilTests.cs
+++ b/Ontology.Tests/ReflectionUtilTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProtoScript.Interpretter;
+using Ontology.Simulation;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Ontology.Tests
+{
+    [TestClass]
+    public sealed class ReflectionUtilTests
+    {
+        [TestInitialize]
+        public void Init()
+        {
+            Initializer.Initialize();
+        }
+
+        private static class OverloadTarget
+        {
+            public static string Echo(int v) => "int";
+            public static string Echo(string v) => "string";
+            public static string Echo(object v) => "object";
+
+            public static string Add(int a, int b) => "int-int";
+            public static string Add(object a, object b) => "obj-obj";
+        }
+
+        [TestMethod]
+        public void GetMethod_PicksStringOverObject()
+        {
+            MethodInfo? info = ReflectionUtil.GetMethod(
+                typeof(OverloadTarget),
+                "Echo",
+                new List<Type> { typeof(string) });
+            Assert.IsNotNull(info);
+            Assert.AreEqual(typeof(string), info.GetParameters()[0].ParameterType);
+        }
+
+        [TestMethod]
+        public void GetMethod_PicksIntOverObjectWhenUsingWrapper()
+        {
+            MethodInfo? info = ReflectionUtil.GetMethod(
+                typeof(OverloadTarget),
+                "Echo",
+                new List<Type> { typeof(IntWrapper) });
+            Assert.IsNotNull(info);
+            Assert.AreEqual(typeof(int), info.GetParameters()[0].ParameterType);
+        }
+
+        [TestMethod]
+        public void GetMethod_HandlesMultipleParameters()
+        {
+            MethodInfo? info = ReflectionUtil.GetMethod(
+                typeof(OverloadTarget),
+                "Add",
+                new List<Type> { typeof(IntWrapper), typeof(IntWrapper) });
+            Assert.IsNotNull(info);
+            ParameterInfo[] p = info.GetParameters();
+            Assert.AreEqual(typeof(int), p[0].ParameterType);
+            Assert.AreEqual(typeof(int), p[1].ParameterType);
+        }
+    }
+}

--- a/ProtoScript.Interpretter/ReflectionUtil.cs
+++ b/ProtoScript.Interpretter/ReflectionUtil.cs
@@ -3,32 +3,108 @@ using System.Reflection;
 
 namespace ProtoScript.Interpretter
 {
-	public class ReflectionUtil
-	{
-		static public MethodInfo GetMethod(System.Type type, string strMethodName, List<System.Type> lstParameters)
-		{
-			if (lstParameters.Any(x => x == null))
-				return type.GetMethods().FirstOrDefault(x => x.Name == strMethodName && x.GetParameters().Length == lstParameters.Count);
+        public class ReflectionUtil
+        {
+                /// <summary>
+                /// Enumerate all candidate methods that have the specified name and arity.
+                /// </summary>
+                static public IEnumerable<MethodInfo> GetCandidateMethods(System.Type type, string name, int arity)
+                {
+                        return type.GetMethods()
+                                .Where(m => m.Name == name && m.GetParameters().Length == arity);
+                }
 
-			MethodInfo methodInfo = type.GetMethod(strMethodName, lstParameters.ToArray());
-			if (null == methodInfo)
-			{
-				for (int i = 0; i < lstParameters.Count; i++)
-				{
-					System.Type typeParam = lstParameters[i];
+                /// <summary>
+                /// Try to resolve the best matching method for the provided argument types.
+                /// </summary>
+                static public MethodInfo? GetMethod(System.Type type, string strMethodName, List<System.Type> lstParameters)
+                {
+                        if (lstParameters.Any(x => x == null))
+                                return GetCandidateMethods(type, strMethodName, lstParameters.Count).FirstOrDefault();
 
-					if (typeParam == typeof(IntWrapper))
-						lstParameters[i] = typeof(int);
+                        // First try an exact match using the runtime types.
+                        MethodInfo? methodInfo = type.GetMethod(strMethodName, lstParameters.ToArray());
+                        if (null != methodInfo)
+                                return methodInfo;
 
-					if (typeParam == typeof(StringWrapper))
-						lstParameters[i] = typeof(string);
-				}
+                        // Attempt again after normalising wrappers to their primitive counterparts.
+                        List<System.Type> normalized = new List<System.Type>(lstParameters);
+                        for (int i = 0; i < normalized.Count; i++)
+                        {
+                                System.Type typeParam = normalized[i];
 
-				methodInfo = type.GetMethod(strMethodName, lstParameters.ToArray());
-			}
+                                if (typeParam == typeof(IntWrapper))
+                                        normalized[i] = typeof(int);
+                                else if (typeParam == typeof(StringWrapper))
+                                        normalized[i] = typeof(string);
+                                else if (typeParam == typeof(DoubleWrapper))
+                                        normalized[i] = typeof(double);
+                                else if (typeParam == typeof(BoolWrapper))
+                                        normalized[i] = typeof(bool);
+                        }
 
-			return methodInfo;
-		}
+                        methodInfo = type.GetMethod(strMethodName, normalized.ToArray());
+                        if (null != methodInfo)
+                                return methodInfo;
+
+                        // Enumerate candidates and pick the most compatible one.
+                        MethodInfo? best = null;
+                        int bestScore = int.MaxValue;
+                        foreach (MethodInfo candidate in GetCandidateMethods(type, strMethodName, lstParameters.Count))
+                        {
+                                ParameterInfo[] parameters = candidate.GetParameters();
+                                int score = 0;
+                                bool compatible = true;
+
+                                for (int i = 0; i < parameters.Length; i++)
+                                {
+                                        System.Type argType = lstParameters[i];
+                                        System.Type paramType = parameters[i].ParameterType;
+
+                                        if (argType == paramType)
+                                                continue;
+
+                                        // handle wrappers
+                                        if (argType == typeof(IntWrapper) && paramType == typeof(int))
+                                        {
+                                                score += 1;
+                                                continue;
+                                        }
+                                        if (argType == typeof(StringWrapper) && paramType == typeof(string))
+                                        {
+                                                score += 1;
+                                                continue;
+                                        }
+                                        if (argType == typeof(DoubleWrapper) && paramType == typeof(double))
+                                        {
+                                                score += 1;
+                                                continue;
+                                        }
+                                        if (argType == typeof(BoolWrapper) && paramType == typeof(bool))
+                                        {
+                                                score += 1;
+                                                continue;
+                                        }
+
+                                        if (paramType.IsAssignableFrom(argType))
+                                        {
+                                                score += 2;
+                                                continue;
+                                        }
+
+                                        compatible = false;
+                                        break;
+                                }
+
+                                if (compatible && score < bestScore)
+                                {
+                                        best = candidate;
+                                        bestScore = score;
+                                }
+                        }
+
+                        return best;
+                }
 
 		static public bool HasBaseType(System.Type typeTarget, System.Type type)
 		{

--- a/docs/MethodResolutionStrategy.md
+++ b/docs/MethodResolutionStrategy.md
@@ -1,0 +1,17 @@
+# Method Resolution Strategy
+
+`ReflectionUtil.GetMethod` selects the most suitable .NET method when several overloads
+match a name and parameter count. The algorithm is:
+
+1. Enumerate all candidate methods with the same name and arity.
+2. Try to locate an exact match using the provided argument types.
+3. If that fails, normalise wrapper types (e.g., `IntWrapper` → `int`) and search again.
+4. If no direct match is found, each candidate is scored:
+   - `0` for parameters whose types exactly match the argument types.
+   - `1` when wrappers map to their primitive counterparts.
+   - `2` when the candidate parameter type is assignable from the argument type.
+   - Incompatible parameters discard the candidate.
+5. The candidate with the lowest score is returned, or `null` if none are compatible.
+
+This approach ensures that strongly typed overloads are chosen ahead of more
+general versions such as those accepting `object` parameters.


### PR DESCRIPTION
## Summary
- implement candidate method enumeration and scoring in `ReflectionUtil`
- document method resolution strategy
- add unit tests covering overload selection

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a522fd8b0832db83ef80061806b58