### PR TITLE
Support wwwroot-relative project paths

### DIFF
--- a/Buffaly.Ontology.Portal/Program.cs
+++ b/Buffaly.Ontology.Portal/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using RooTrax.Common;
 using System.Reflection;
 using WebAppUtilities;
+using ProtoScript.Extensions;
 
 public class Program
 {
@@ -27,7 +28,9 @@ public class Program
 
 		builder.Services.AddDistributedMemoryCache();
 
-		var app = builder.Build();
+                var app = builder.Build();
+                // Make ProtoScriptWorkbench aware of wwwroot for relative project paths
+                ProtoScript.Extensions.ProtoScriptWorkbench.SetWebRoot(app.Environment.WebRootPath);
 
 		// Configure the HTTP request pipeline.
 		if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- allow ProtoScriptWorkbench to store a web root
- resolve project paths against web root when needed
- ensure CreateNewFile and LoadProjectInternal use absolute project paths
- set the workbench web root from the portal's Program.cs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a527b0e58832db52c0b279a90a99e