### PR TITLE
Fix prototype lookup in Collection

### DIFF
--- a/Ontology/Collection.cs
+++ b/Ontology/Collection.cs
@@ -44,10 +44,10 @@ namespace Ontology
 			this.Children.AddRange(lstPrototypes);
 		}
 
-		public Collection(IEnumerable<int> lstPrototypes) : base(Collection.PrototypeID)
-		{
-			this.Children.AddRange(lstPrototypes.Select(x => Prototypes.GetPrototype(PrototypeID)));
-		}
+                public Collection(IEnumerable<int> lstPrototypes) : base(Collection.PrototypeID)
+                {
+                        this.Children.AddRange(lstPrototypes.Select(x => Prototypes.GetPrototype(x)));
+                }
 		public Collection(Collection col) : base(Collection.PrototypeID)
 		{
 			this.Children.AddRange(col);


### PR DESCRIPTION
## Summary
- fix LINQ selector for prototype IDs

## Testing
- `dotnet test Ontology/Ontology8.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a52e28e98832d8aeceac3c0b363d0