### PR TITLE
Fix Lexemes2.cs trailing prompt

### DIFF
--- a/Ontology/Lexemes2.cs
+++ b/Ontology/Lexemes2.cs
@@ -127,4 +127,3 @@ namespace Ontology
 		}
 	}
 }    
-		


### PR DESCRIPTION
## Summary
- remove stray shell prompt line from `Lexemes2.cs`

## Testing
- `dotnet build Ontology/Ontology.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a52eeea48832d9bb04769626c56a9