### PR TITLE
Fix null reference warnings in CSHTML page models

### DIFF
--- a/Buffaly.Ontology.Portal/BaseModel.cs
+++ b/Buffaly.Ontology.Portal/BaseModel.cs
@@ -62,8 +62,9 @@ namespace Buffaly.SemanticDB.Portal
         {
             oHandler.EvaluateFunction1("using", "Administrator\\LeftMenu.ks.html");
 
-			return oHandler.EvaluateFile(FileUtil.BuildPath(oHandler.GetRootDir(), "Administrator\\LeftMenu.ks.html"));
-		}
+            string rootDir = oHandler.GetRootDir() ?? string.Empty;
+            return oHandler.EvaluateFile(FileUtil.BuildPath(rootDir, "Administrator\\LeftMenu.ks.html")) ?? string.Empty;
+        }
 
 		public string? SidebarMenu
         {
@@ -110,11 +111,11 @@ namespace Buffaly.SemanticDB.Portal
             }
             else if (values.Count == 1)
             {
-                return values[0];
+                return values[0] ?? string.Empty;
             }
             else
             {
-                return string.Join(", ", values);
+                return string.Join(", ", values.ToArray());
             }
         }
     }

--- a/Buffaly.Ontology.Portal/Pages/Error.cshtml.cs
+++ b/Buffaly.Ontology.Portal/Pages/Error.cshtml.cs
@@ -13,7 +13,7 @@ namespace Buffaly.Admin.Portal.Pages
     {
 
         public string? RequestId { get; set; }
-        public string ErrorMessage { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/Buffaly.Ontology.Portal/Pages/Index.cshtml.cs
+++ b/Buffaly.Ontology.Portal/Pages/Index.cshtml.cs
@@ -27,9 +27,10 @@ namespace Buffaly.Admin.Portal.Pages
 			}
 		}
 
-		public string GetSidebarMenu(kScript3.kScriptControl oHandler)
-		{
-			return oHandler.EvaluateFile(FileUtil.BuildPath(oHandler.GetRootDir(), "Administrator\\LeftMenu.ks.html"));
-		}
+                public string GetSidebarMenu(kScript3.kScriptControl oHandler)
+                {
+                        string rootDir = oHandler.GetRootDir() ?? string.Empty;
+                        return oHandler.EvaluateFile(FileUtil.BuildPath(rootDir, "Administrator\\LeftMenu.ks.html")) ?? string.Empty;
+                }
 	}
 }

--- a/Buffaly.Ontology.Portal/Pages/k.cshtml.cs
+++ b/Buffaly.Ontology.Portal/Pages/k.cshtml.cs
@@ -95,7 +95,7 @@ namespace Buffaly.Admin.Portal.Pages
 				//kScript3.kScriptControl kScript = RooTraxState.kScriptControl;
 
 
-                kScript3.kScriptControl kScript = null;
+                kScript3.kScriptControl? kScript = null;
                 if (StringUtil.IsEmpty(this.Handler) || StringUtil.EqualNoCase(this.Handler, "Buffaly.SemanticDB.UI"))
                 {
                     kScript = Buffaly.SemanticDB.UI.RooTraxState.kScriptControl; ;
@@ -108,7 +108,9 @@ namespace Buffaly.Admin.Portal.Pages
 				}
 
 
-				kScript3.SymbolTable oSymbolTable = (kScript.GetSymbolTable());
+                                if (kScript == null)
+                                    throw new InvalidOperationException("kScript is not initialized");
+                                kScript3.SymbolTable oSymbolTable = kScript.GetSymbolTable();
 
 				try
 				{
@@ -216,7 +218,7 @@ namespace Buffaly.Admin.Portal.Pages
 			return Page();
 		}
 
-        private string BuildErrorMessage(Exception err)
+        private string BuildErrorMessage(Exception? err)
         {
             if (err == null) return string.Empty;
 
@@ -230,9 +232,9 @@ namespace Buffaly.Admin.Portal.Pages
         <div class=""alert alert-danger"" role=""alert"">
             {WebUtility.HtmlEncode(err.Message)}
             <h3>Source</h3>
-            <pre>{WebUtility.HtmlEncode(err.Source)}</pre>
+            <pre>{WebUtility.HtmlEncode(err.Source ?? string.Empty)}</pre>
             <h3>Stack Trace</h3>
-            <pre>{err.StackTrace}</pre>
+            <pre>{err.StackTrace ?? string.Empty}</pre>
         </div>
         {innerMessage}";
 
@@ -248,23 +250,25 @@ namespace Buffaly.Admin.Portal.Pages
 			return string.Empty;
 		}
 
-		private object TryEvaluateEx(string strClass, string strMember, ref kScript3.SymbolTable oSymbolTable, ref kScript3.kScriptControl oHandler)
-		{
-			if (oSymbolTable.GetScope(strClass).Symbols.ContainsKey(strMember))
-			{
-				return oHandler.EvaluateFunctionNObjectsEx(strClass + "." + strMember, new List<object>(), ref oSymbolTable);
-			}
+                private object? TryEvaluateEx(string strClass, string strMember, ref kScript3.SymbolTable oSymbolTable, ref kScript3.kScriptControl oHandler)
+                {
+                        if (oSymbolTable.GetScope(strClass).Symbols.ContainsKey(strMember))
+                        {
+                                return oHandler.EvaluateFunctionNObjectsEx(strClass + "." + strMember, new List<object>(), ref oSymbolTable);
+                        }
 
 			return string.Empty;
 		}
-		public string GetSidebarMenu(kScript3.kScriptControl oHandler)
-		{
-			return oHandler.EvaluateFile(FileUtil.BuildPath(oHandler.GetRootDir(), "Administrator\\LeftMenu.ks.html"));
-		}
-		public string GetFileMenu(kScript3.kScriptControl oHandler)
-		{
-			return oHandler.EvaluateFile(FileUtil.BuildPath(oHandler.GetRootDir(), "Administrator\\FileMenu.ks.html"));
-		}
+                public string GetSidebarMenu(kScript3.kScriptControl oHandler)
+                {
+                        string rootDir = oHandler.GetRootDir() ?? string.Empty;
+                        return oHandler.EvaluateFile(FileUtil.BuildPath(rootDir, "Administrator\\LeftMenu.ks.html")) ?? string.Empty;
+                }
+                public string GetFileMenu(kScript3.kScriptControl oHandler)
+                {
+                        string rootDir = oHandler.GetRootDir() ?? string.Empty;
+                        return oHandler.EvaluateFile(FileUtil.BuildPath(rootDir, "Administrator\\FileMenu.ks.html")) ?? string.Empty;
+                }
 
 
 	}

--- a/Buffaly.Ontology.Portal/Program.cs
+++ b/Buffaly.Ontology.Portal/Program.cs
@@ -154,9 +154,10 @@ public class Program
 			jsonWs.SetOptions(jsonWsOptions);
 
 			// Map API routes
-			foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
-			{
-				string strUrl = "/api/" + type.Namespace.ToString().ToLower() + "/" + GetUrlSafeName(type.Name) + "/" + GetUrlSafeName(method.Name);
+                        foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                        {
+                                string ns = type.Namespace ?? string.Empty;
+                                string strUrl = "/api/" + ns.ToLowerInvariant() + "/" + GetUrlSafeName(type.Name) + "/" + GetUrlSafeName(method.Name);
 				// Map the API route with authorization
 				endpoints.Map(strUrl, async (HttpContext context) =>
 				{


### PR DESCRIPTION
## Summary
- guard against null Namespace when creating API route URLs
- ensure `GetSidebarMenu` & `GetFileMenu` handle null root directory
- allow nullable return for `TryEvaluateEx` and check kScript initialization
- prevent null strings in BaseModel helpers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad86de108832db041c01bf082dedc