### PR TITLE
Add SemDB IDE editor page

### DIFF
--- a/Buffaly.Ontology.Portal/Pages/Editor.cshtml
+++ b/Buffaly.Ontology.Portal/Pages/Editor.cshtml
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SemDB IDE</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/theme/neat.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/mode/javascript/javascript.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/search/searchcursor.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/search/search.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/dialog/dialog.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/dialog/dialog.css">
+
+<link rel="stylesheet" href="~/css/editor.css">
+</head>
+<body class="flex flex-col h-screen bg-gray-100 text-gray-800 font-sans antialiased">
+
+<header id="appHeader" class="py-2 px-4 bg-gray-50 border-b border-gray-300 text-lg font-semibold flex items-center shadow-sm">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-2 text-blue-600"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.438 60.438 0 0 0-.491 0A.75.75 0 0 1 3 9.398V8.25c0-.828.75-1.5 1.5-1.5h5.25c.828 0 1.5.672 1.5 1.5v1.148c0 .386-.158.75-.43 1.035a60.093 60.093 0 0 0-.42 0H4.26Zm0 0A60.438 60.438 0 0 1 4.26 10.147M13.5 4.868a60.438 60.438 0 0 1 .491 0A.75.75 0 0 0 15 5.62v1.148a.75.75 0 0 0 .43 1.035A60.093 60.093 0 0 1 15.853 8c.262.068.504.15.728.244M13.5 4.868a60.438 60.438 0 0 0-.491 0H8.25c-.828 0-1.5.672-1.5 1.5v1.148c0 .386.158.75.43 1.035a60.093 60.093 0 0 0 .421 0H13.5Zm0 0A60.438 60.438 0 0 1 13.5 4.868M4.26 15.853A60.438 60.438 0 0 0 3.769 15.75H3A.75.75 0 0 1 2.25 15V13.852c0-.828.75-1.5 1.5-1.5h5.25c.828 0 1.5.672 1.5 1.5v1.148a.75.75 0 0 1-.43 1.035a60.093 60.093 0 0 0-.421 0H4.26Zm0 0A60.438 60.438 0 0 1 4.26 15.853m9.24-1.199a60.438 60.438 0 0 1 .491 0A.75.75 0 0 0 15 15.38V14.23c0-.828.75-1.5 1.5-1.5h5.25c.828 0 1.5.672 1.5 1.5v1.148a.75.75 0 0 0 .43 1.035a60.093 60.093 0 0 1 .421 0H13.5Zm0 0A60.438 60.438 0 0 0 13.5 14.654M21.75 9.398a.75.75 0 0 0-.75-.75h-5.25c-.828 0-1.5.672-1.5 1.5v1.148a.75.75 0 0 0 .43 1.035c.161.05.324.09.49.123a.75.75 0 0 0 .73-.016C16.334 11.01 17.01 11 18 11c.99 0 1.665.01 2.239.048a.75.75 0 0 0 .73.016c.165-.033.329-.073.49-.123A.75.75 0 0 0 21.75 10.5V9.398Z" /></svg>
+<span id="headerAppName">SemDB</span>
+<span id="headerProjectName" class="ml-2 text-gray-500 font-normal text-base"></span>
+</header>
+
+<nav class="flex items-center space-x-1 px-3 py-1.5 bg-gray-200 border-b border-gray-300 text-sm">
+<div class="dropdown"><button class="px-2 py-1 hover:bg-gray-300 rounded-sm focus:outline-none">File</button><div class="dropdown-content"><button id="menuLoadProject">Load Project...</button><button id="menuAddFile">Add File...</button><div class="menu-separator"></div><button id="menuSaveFile">Save File</button><button id="menuSaveFileAs">Save File As...</button><div class="menu-separator"></div><button id="menuExit">Exit</button></div></div>
+<div class="dropdown"><button class="px-2 py-1 hover:bg-gray-300 rounded-sm focus:outline-none">Edit</button><div class="dropdown-content"><button id="editUndo">Undo</button><button id="editRedo">Redo</button><div class="menu-separator"></div><button id="editCut">Cut</button><button id="editCopy">Copy</button><button id="editPaste">Paste</button><div class="menu-separator"></div><button id="editFind">Find</button></div></div>
+<div class="dropdown"><button class="px-2 py-1 hover:bg-gray-300 rounded-sm focus:outline-none">Build</button><div class="dropdown-content"><button id="menuCompile">Compile</button></div></div>
+<div class="dropdown"><button class="px-2 py-1 hover:bg-gray-300 rounded-sm focus:outline-none">View</button><div class="dropdown-content"><button id="menuToggleSolutionExplorer">Toggle Solution Explorer</button><button id="menuToggleOutputWindow">Toggle Output Panel</button></div></div>
+<div class="dropdown"><button class="px-2 py-1 hover:bg-gray-300 rounded-sm focus:outline-none">Settings</button><div class="dropdown-content"><label><input type="checkbox" id="settingShowTypeOfs" class="menu-item-checkbox"> Show Type Ofs</label><label><input type="checkbox" id="settingDebugMode" class="menu-item-checkbox"> Debug Mode</label><label><input type="checkbox" id="settingResumeExecution" class="menu-item-checkbox"> Resume Execution</label></div></div>
+</nav>
+
+<div class="flex-grow flex p-1 gap-1 overflow-hidden">
+<section class="flex-grow flex flex-col bg-white p-1 rounded-md shadow border border-gray-200 min-w-0">
+<textarea id="codeEditor">// Welcome to SemDB IDE! // Load a project or add a file to start. </textarea>
+</section>
+<aside id="rightPanel" class="w-[320px] flex flex-col bg-white p-3 rounded-md shadow border border-gray-200 gap-2">
+<div class="flex border-b border-gray-300 mb-1">
+<button data-pane="right" data-tab="solutionExplorerTab" class="tab-button right-tab-button active">Solution Explorer</button>
+<button data-pane="right" data-tab="symbolsTab" class="tab-button right-tab-button">Symbols</button>
+</div>
+<div id="solutionExplorerTab" class="tab-content right-tab-content active flex flex-col flex-grow gap-2 overflow-hidden">
+<input type="search" id="searchFiles" placeholder="Search files..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
+<div id="fileList" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+</div>
+<div id="symbolsTab" class="tab-content right-tab-content flex flex-col flex-grow gap-2 overflow-hidden"> <input type="search" id="searchSymbols" placeholder="Search symbols..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
+<div id="symbolList" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"><p class="text-gray-500 text-xs p-1">Select a file to view its symbols.</p></div>
+</div>
+</aside>
+</div>
+
+<div id="outputResizer"></div>
+
+<footer id="outputWindow" class="h-[250px] flex flex-col bg-white shadow border-t border-gray-300 mt-1">
+<div class="flex border-b border-gray-300 px-2 pt-1">
+<button data-pane="bottom" data-tab="consoleContent" class="tab-button bottom-tab-button active">Console</button>
+<button data-pane="bottom" data-tab="chatContent" class="tab-button bottom-tab-button">Chat</button>
+<button id="clearConsoleBtn" class="ml-auto bg-red-500 hover:bg-red-600 text-white px-2 py-0.5 text-xs rounded-md font-medium focus:outline-none focus:ring-1 focus:ring-red-400 mb-1 self-center">Clear Console</button>
+</div>
+<div class="flex-grow p-2 overflow-hidden">
+<div id="consoleContent" class="tab-content bottom-tab-content active bottom-panel-tab-content">
+<textarea id="consoleOutput" readonly class="bottom-panel-textarea" placeholder="Console output, command history, and results will appear here..."></textarea>
+<div class="immediate-input-area">
+<input type="text" id="immediateCommandInput" placeholder="Enter command...">
+<button id="runImmediateCmdBtn" class="bg-blue-600 hover:bg-blue-700 text-white rounded-md">Run</button>
+</div>
+</div>
+<div id="chatContent" class="tab-content bottom-tab-content bottom-panel-tab-content"><p class="text-gray-500 text-xs p-2">Chat functionality placeholder.</p></div>
+</div>
+</footer>
+<script src="~/js/editor.js"></script>
+
+<div id="loadProjectModal" class="modal"><div class="modal-content"><div class="modal-header"><span class="close-button" id="closeModalBtn">&times;</span><h2 class="text-lg font-semibold">Load Project</h2></div><div class="py-4"><label for="modalProjectPath" class="block text-sm font-medium text-gray-700 mb-1">Project File Path (.pts)</label><input type="text" id="modalProjectPath" placeholder="C:\path\to\your\project.pts" class="w-full bg-gray-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"><p class="text-xs text-gray-500 mt-1">Enter the full path to your project file.</p></div><div class="modal-footer"><button id="modalCancelLoadBtn" class="px-3 py-1.5 text-sm bg-gray-200 hover:bg-gray-300 rounded-md mr-2">Cancel</button><button id="modalConfirmLoadBtn" class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Load</button></div></div></div>
+
+</body>
+</html>

--- a/Buffaly.Ontology.Portal/wwwroot/css/editor.css
+++ b/Buffaly.Ontology.Portal/wwwroot/css/editor.css
@@ -1,0 +1,52 @@
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: #e2e8f0; }
+::-webkit-scrollbar-thumb { background: #a0aec0; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #718096; }
+
+.tab-content:not(.active) { display: none !important; }
+
+.tab-button { border-bottom: 2px solid transparent; padding: 0.375rem 0.75rem; font-size: 0.75rem; font-weight: 500; color: #4a5568; }
+.tab-button:hover { color: #2c5282; }
+.tab-button.active { border-bottom-color: #4299e1; color: #2b6cb0; }
+
+.file-item:hover, .symbol-item:hover { background-color: #e2e8f0; }
+.file-item.active, .symbol-item.active { background-color: #bee3f8; color: #2b6cb0; }
+.CodeMirror { height: 100%; font-size: 14px; border: 1px solid #cbd5e0; border-radius: 0.375rem; }
+#outputResizer { height: 8px; background-color: #e2e8f0; cursor: ns-resize; transition: background-color 0.2s; }
+#outputResizer:hover { background-color: #cbd5e0; }
+.dropdown { position: relative; display: inline-block; }
+.dropdown-content { display: none; position: absolute; background-color: #f9fafb; min-width: 200px; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.1); z-index: 100; border: 1px solid #e5e7eb; border-radius: 0.25rem; }
+.dropdown-content button, .dropdown-content a, .dropdown-content label { color: #374151; padding: 8px 12px; text-decoration: none; display: block; width: 100%; text-align: left; font-size: 0.875rem; cursor: pointer; }
+.dropdown-content button:hover, .dropdown-content a:hover, .dropdown-content label:hover { background-color: #e5e7eb; }
+.dropdown:hover .dropdown-content { display: block; }
+.menu-separator { height: 1px; background-color: #e5e7eb; margin: 4px 0; }
+.menu-item-checkbox { margin-right: 8px; vertical-align: middle; }
+.dropdown-content label { display: flex; align-items: center; }
+.modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+.modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 500px; border-radius: 0.375rem; color: #1f2937; }
+.modal-header { padding-bottom: 10px; border-bottom: 1px solid #e5e7eb; }
+.modal-footer { padding-top: 10px; border-top: 1px solid #e5e7eb; text-align: right; }
+.close-button { color: #aaa; float: right; font-size: 28px; font-weight: bold; }
+.close-button:hover, .close-button:focus { color: black; text-decoration: none; cursor: pointer; }
+
+.bottom-panel-tab-content { height: 100%; display: flex; flex-direction: column; }
+/* Single textarea for all console output */
+#consoleOutput {
+flex-grow: 1;
+width: 100%;
+background-color: #f9fafb;
+color: #374151;
+padding: 0.5rem;
+font-size: 0.75rem;
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+border-radius: 0.375rem;
+border: 1px solid #d1d5db;
+resize: none;
+min-height: 100px; /* Ensure it's visible */
+}
+.immediate-input-area { display: flex; gap: 0.5rem; padding-top: 0.5rem; }
+#immediateCommandInput { flex-grow: 1; font-size: 0.75rem; padding: 0.25rem 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem; }
+#runImmediateCmdBtn { padding: 0.25rem 0.75rem; font-size: 0.75rem; }
+
+.symbol-item { padding: 0.25rem 0.375rem; border-radius: 0.25rem; cursor: pointer; display: flex; align-items: center; font-size: 0.75rem; }
+.symbol-icon { margin-right: 0.375rem; width: 0.875rem; height: 0.875rem; }

--- a/Buffaly.Ontology.Portal/wwwroot/js/editor.js
+++ b/Buffaly.Ontology.Portal/wwwroot/js/editor.js
@@ -1,0 +1,265 @@
+const consoleOutput = document.getElementById('consoleOutput'); // Unified console output
+const immediateCommandInput = document.getElementById('immediateCommandInput');
+const runImmediateCmdBtn = document.getElementById('runImmediateCmdBtn');
+const headerProjectName = document.getElementById('headerProjectName');
+const fileList = document.getElementById('fileList');
+const symbolList = document.getElementById('symbolList');
+const searchFilesInput = document.getElementById('searchFiles');
+const searchSymbolsInput = document.getElementById('searchSymbols');
+let editor;
+let currentProjectName = "Untitled Project";
+let currentFileSymbols = [];
+
+function updateTitle() {
+document.title = `SemDB IDE - ${currentProjectName}`;
+headerProjectName.textContent = `- ${currentProjectName}`;
+}
+updateTitle();
+
+function appendToConsole(message, type = 'LOG') {
+const timestamp = new Date().toLocaleTimeString();
+let prefix = "";
+if (type === 'CMD') { prefix = "CMD> "; }
+else if (type === 'RESULT') { prefix = "=> "; }
+else if (type === 'WARN') { prefix = "WARN: "; }
+else if (type === 'ERROR') { prefix = "ERROR: "; }
+else if (type === 'INFO') { prefix = "INFO: "; }
+// For 'LOG', no specific prefix, just the timestamped message
+
+consoleOutput.value += `[${timestamp}] ${prefix}${message}\n`;
+consoleOutput.scrollTop = consoleOutput.scrollHeight;
+}
+
+editor = CodeMirror.fromTextArea(document.getElementById("codeEditor"), {
+lineNumbers: true, mode: "javascript", theme: "neat", matchBrackets: true, autoCloseBrackets: true, lineWrapping: true,
+});
+
+function switchTab(panePrefix, tabIdToShow) {
+document.querySelectorAll(`button[data-pane='${panePrefix}']`).forEach(button => {
+button.classList.remove('active');
+});
+document.querySelectorAll(`.${panePrefix}-tab-content`).forEach(content => {
+content.classList.remove('active');
+});
+const activeButton = document.querySelector(`button[data-pane='${panePrefix}'][data-tab='${tabIdToShow}']`);
+if (activeButton) { activeButton.classList.add('active'); }
+const activeTabContent = document.getElementById(tabIdToShow);
+if (activeTabContent) { activeTabContent.classList.add('active'); }
+}
+
+document.querySelectorAll('.tab-button').forEach(button => {
+button.addEventListener('click', () => {
+const pane = button.dataset.pane;
+const tabId = button.dataset.tab;
+switchTab(pane, tabId);
+const tabNameFriendly = button.textContent;
+appendToConsole(`Switched to ${pane} panel, tab: ${tabNameFriendly}`, 'DEBUG'); // Log to unified console
+});
+});
+
+switchTab('right', 'solutionExplorerTab');
+switchTab('bottom', 'consoleContent');
+
+
+function highlightActiveFile(selectedItem) {
+document.querySelectorAll('#fileList .file-item').forEach(item => item.classList.remove('active'));
+if (selectedItem) selectedItem.classList.add('active');
+}
+
+function parseAndDisplaySymbols(fileName, codeContent) {
+currentFileSymbols = [];
+symbolList.innerHTML = '';
+const functionRegex = /function\s+([a-zA-Z0-9_]+)\s*\(/g;
+const varRegex = /(?:var|let|const)\s+([a-zA-Z0-9_]+)/g;
+let match;
+const fileTitle = document.createElement('p');
+fileTitle.className = 'text-xs text-gray-500 px-1 pt-1 pb-0.5 font-semibold';
+fileTitle.textContent = `Symbols in ${fileName.split('\\').pop().split('/').pop()}:`;
+symbolList.appendChild(fileTitle);
+
+while ((match = functionRegex.exec(codeContent)) !== null) {
+const matchStartPos = editor.posFromIndex(match.index);
+currentFileSymbols.push({ name: match[1], type: 'function', line: matchStartPos.line + 1 });
+}
+while ((match = varRegex.exec(codeContent)) !== null) {
+if (!['var', 'let', 'const'].includes(match[1])) {
+const matchStartPos = editor.posFromIndex(match.index);
+currentFileSymbols.push({ name: match[1], type: 'variable', line: matchStartPos.line + 1 });
+}
+}
+
+if (fileName.includes("Base.pts")) {
+const baseObjIndex = codeContent.indexOf("BaseObject");
+const initIndex = codeContent.indexOf("InitializeSystem");
+if(baseObjIndex !== -1) currentFileSymbols.push({ name: "BaseObject", type: 'class', line: editor.posFromIndex(baseObjIndex).line + 1 });
+if(initIndex !== -1) currentFileSymbols.push({ name: "InitializeSystem", type: 'method', line: editor.posFromIndex(initIndex).line + 1 });
+}
+	if (fileName.includes("Articles.pts")) {
+const articleIndex = codeContent.indexOf("Article");
+const fetchIndex = codeContent.indexOf("fetchContent");
+const displayIndex = codeContent.indexOf("displayArticle");
+if(articleIndex !== -1) currentFileSymbols.push({ name: "Article", type: 'class', line: editor.posFromIndex(articleIndex).line + 1 });
+if(fetchIndex !== -1) currentFileSymbols.push({ name: "fetchContent", type: 'method', line: editor.posFromIndex(fetchIndex).line + 1 });
+if(displayIndex !== -1) currentFileSymbols.push({ name: "displayArticle", type: 'method', line: editor.posFromIndex(displayIndex).line + 1 });
+}
+
+if (currentFileSymbols.length === 0) {
+const noSymbolsMsg = document.createElement('p');
+noSymbolsMsg.className = 'text-gray-500 text-xs p-1';
+noSymbolsMsg.textContent = 'No symbols found in this file.';
+symbolList.appendChild(noSymbolsMsg);
+} else {
+renderSymbolList(currentFileSymbols);
+}
+}
+
+function getSymbolIcon(type) {
+let iconSvg = '';
+switch (type) {
+case 'function': iconSvg = `<svg viewBox="0 0 16 16" fill="#805AD5" class="symbol-icon"><path d="M4 14V2h5.5l3.5 3.5V14H4zm1-1h7V6H9V3H5v10zM6.5 9H8V7.5h2V9h1.5v1H10v1.5H8V13H6.5v-1.5H5V10h1.5V9z"/></svg>`; break;
+case 'variable': iconSvg = `<svg viewBox="0 0 16 16" fill="#3182CE" class="symbol-icon"><path d="M4 2v12h8V2H4zm1 1h6v2L8 7l-3-2V3zm0 5l3 2 3-2v5H5V8z"/></svg>`; break;
+case 'class': iconSvg = `<svg viewBox="0 0 16 16" fill="#DD6B20" class="symbol-icon"><path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 1.5a5.5 5.5 0 014.606 8.036L5.964 3.964A5.466 5.466 0 018 2.5zM3.964 12.036L10.036 5.964A5.5 5.5 0 013.964 12.036z"/></svg>`; break;
+case 'method': iconSvg = `<svg viewBox="0 0 16 16" fill="#319795" class="symbol-icon"><path d="M3 3h10v1H3V3zm0 2h10v1H3V5zm0 3h4v1H3V8zm0 2h4v1H3v-1zm5-2h5v1H8V8zm0 2h5v1H8v-1zM3 13h10v1H3v-1z"/></svg>`; break;
+default: iconSvg = `<svg viewBox="0 0 16 16" fill="#718096" class="symbol-icon"><circle cx="8" cy="8" r="3"/></svg>`;
+}
+return iconSvg;
+}
+
+function renderSymbolList(symbolsToRender) {
+symbolList.querySelectorAll('.symbol-item, .no-symbols-message').forEach(el => el.remove());
+if (symbolsToRender.length === 0 && symbolList.querySelector('.text-xs.text-gray-500.px-1.pt-1.pb-0\\.5.font-semibold') === null) {
+const noSymbolsMsg = document.createElement('p'); noSymbolsMsg.className = 'text-gray-500 text-xs p-1 no-symbols-message'; noSymbolsMsg.textContent = 'No symbols match your search or in the current file.'; symbolList.appendChild(noSymbolsMsg); return;
+}
+	if (symbolsToRender.length === 0 && searchSymbolsInput.value.trim() !== "") {
+const noMatchMsg = document.createElement('p'); noMatchMsg.className = 'text-gray-500 text-xs p-1 no-symbols-message'; noMatchMsg.textContent = 'No symbols match your search.'; symbolList.appendChild(noMatchMsg); return;
+}
+symbolsToRender.forEach(symbol => {
+const item = document.createElement('div'); item.className = 'symbol-item';
+item.innerHTML = `${getSymbolIcon(symbol.type)} <span class="symbol-name">${symbol.name}</span> <span class="text-gray-400 ml-auto text-xxs">L:${symbol.line}</span>`;
+item.onclick = () => {
+appendToConsole(`Symbol clicked: ${symbol.name} (Type: ${symbol.type}, Line: ${symbol.line})`, 'DEBUG');
+if (typeof symbol.line === 'number' && symbol.line > 0) {
+editor.setCursor({line: symbol.line - 1, ch: 0}); editor.focus();
+const lineHandle = editor.getLineHandle(symbol.line - 1);
+if (lineHandle) { editor.addLineClass(lineHandle, 'background', 'bg-yellow-200'); setTimeout(() => { editor.removeLineClass(lineHandle, 'background', 'bg-yellow-200'); }, 1500); }
+} else { appendToConsole(`Invalid line number for symbol ${symbol.name}: ${symbol.line}`, 'WARN'); }
+};
+symbolList.appendChild(item);
+});
+}
+
+searchSymbolsInput.addEventListener('input', (e) => {
+const searchTerm = e.target.value.toLowerCase();
+const fileTitleElement = symbolList.querySelector('.text-xs.text-gray-500.px-1.pt-1.pb-0\\.5.font-semibold');
+const currentFileTitleHTML = fileTitleElement ? fileTitleElement.outerHTML : '';
+symbolList.innerHTML = currentFileTitleHTML;
+const filteredSymbols = currentFileSymbols.filter(symbol => symbol.name.toLowerCase().includes(searchTerm));
+renderSymbolList(filteredSymbols);
+});
+
+function loadFileContent(fileName) {
+appendToConsole(`Loading file: ${fileName}`, 'INFO');
+let mockContent = `// Content for ${fileName}\n\n// ProtoScript code goes here...\n\n`;
+if (fileName.includes("Annotations.pts")) { mockContent += "function processAnnotation(data) {}\nconst MAX_POINTS = 100;\nvar currentTool = 'select';"; }
+else if (fileName.includes("Articles.pts")) { mockContent += "function Article() {}\nfunction fetchContent(id) {}\nfunction displayArticle(content) {}\nconst DEFAULT_CATEGORY = 'news';"; }
+else if (fileName.includes("Base.pts")) { mockContent += "function BaseObject() {}\nfunction InitializeSystem() {}\nvar config = {};\nlet statusFlag = true;"; }
+else { mockContent += "function genericFunction() {}\n var myData = [];"; }
+editor.setValue(mockContent);
+parseAndDisplaySymbols(fileName, mockContent);
+}
+
+const initialFiles = [ "..\\NL_Project_1.0.1\\Annotations.pts", "..\\NL_Project_1.0.1\\Articles.pts", "..\\NL_Project_1.0.1\\Base.pts", "..\\NL_Project_1.0.1\\Utils.pts", "..\\NL_Project_1.0.1\\Main.pts" ];
+let firstFileDivToLoad = null;
+initialFiles.forEach((fileName, index) => {
+const fileDiv = document.createElement('div'); fileDiv.className = 'file-item p-1.5 rounded-md cursor-pointer text-gray-700'; fileDiv.textContent = fileName;
+fileDiv.onclick = () => { loadFileContent(fileName); highlightActiveFile(fileDiv); };
+fileList.appendChild(fileDiv);
+if (index === 0) { firstFileDivToLoad = fileDiv; }
+});
+if (firstFileDivToLoad) { loadFileContent(firstFileDivToLoad.textContent); highlightActiveFile(firstFileDivToLoad); }
+
+searchFilesInput.addEventListener('input', (e) => {
+const searchTerm = e.target.value.toLowerCase();
+document.querySelectorAll('#fileList .file-item').forEach(item => {
+item.style.display = item.textContent.toLowerCase().includes(searchTerm) ? 'block' : 'none';
+});
+});
+
+document.getElementById('menuLoadProject').addEventListener('click', () => { document.getElementById('loadProjectModal').style.display = 'block'; appendToConsole('Opened Load Project dialog.', 'INFO'); });
+document.getElementById('menuAddFile').addEventListener('click', () => {
+const newFileName = prompt("Enter new file name (e.g., myFile.pts):");
+if (newFileName && newFileName.trim() !== "") {
+const fileDiv = document.createElement('div'); fileDiv.className = 'file-item p-1.5 rounded-md cursor-pointer text-gray-700'; fileDiv.textContent = newFileName;
+fileDiv.onclick = () => { loadFileContent(newFileName); highlightActiveFile(fileDiv); };
+fileList.appendChild(fileDiv); appendToConsole(`Added file: ${newFileName}`, 'INFO');
+loadFileContent(newFileName); highlightActiveFile(fileDiv);
+} else if (newFileName !== null) { appendToConsole('File name cannot be empty.', 'WARN'); }
+});
+document.getElementById('menuCompile').addEventListener('click', () => {
+appendToConsole('Compile action triggered.', 'INFO');
+const code = editor.getValue();
+if (code.trim() === "") { appendToConsole('Editor is empty. Nothing to compile.', 'WARN'); return; }
+appendToConsole('Compilation started...', 'INFO');
+setTimeout(() => appendToConsole('Compilation finished (simulated).', 'INFO'), 1500);
+});
+
+runImmediateCmdBtn.addEventListener('click', () => {
+const command = immediateCommandInput.value.trim();
+if (command === "") { appendToConsole('No command entered.', 'WARN'); return; }
+appendToConsole(command, 'CMD');
+if (command.toLowerCase() === "help") { appendToConsole("Available: help, clear, run_script, get_active_file", 'RESULT'); }
+else if (command.toLowerCase() === "clear") { consoleOutput.value = ""; appendToConsole("Console cleared.", 'RESULT'); }
+else if (command.toLowerCase() === "run_script") {
+appendToConsole("Interpreting current script in editor...", 'LOG');
+const code = editor.getValue();
+if (code.trim() === "") {
+appendToConsole('Editor is empty. Nothing to interpret.', 'WARN');
+} else {
+setTimeout(() => {
+appendToConsole('Interpretation finished (simulated). Result: OK', 'RESULT');
+}, 1000);
+}
+} else if (command.toLowerCase() === "get_active_file") {
+const activeFile = document.querySelector('#fileList .file-item.active');
+if (activeFile) { appendToConsole(`Active file: ${activeFile.textContent}`, 'RESULT'); }
+else { appendToConsole("No file is currently active.", 'RESULT'); }
+}
+else { appendToConsole(`Simulating: ${command}`, 'LOG'); setTimeout(() => appendToConsole(`'${command}' executed. Output: OK`, 'RESULT'), 500); }
+immediateCommandInput.value = "";
+});
+
+['settingShowTypeOfs', 'settingDebugMode', 'settingResumeExecution'].forEach(id => { document.getElementById(id).addEventListener('change', (e) => { appendToConsole(`${e.target.labels[0].textContent.trim()} setting: ${e.target.checked ? 'Enabled' : 'Disabled'}`, 'INFO'); }); });
+['editUndo', 'editRedo', 'editCut', 'editCopy', 'editPaste'].forEach(id => { const btn = document.getElementById(id); if(btn) btn.addEventListener('click', () => { appendToConsole(`${btn.textContent} action clicked.`, 'DEBUG'); if (id === 'editUndo') editor.undo(); else if (id === 'editRedo') editor.redo(); }); });
+const findBtn = document.getElementById('editFind'); if(findBtn) findBtn.addEventListener('click', () => { CodeMirror.commands.find(editor); appendToConsole('Find dialog opened.', 'DEBUG'); });
+
+const loadProjectModal = document.getElementById('loadProjectModal'); const closeModalBtn = document.getElementById('closeModalBtn'); const modalConfirmLoadBtn = document.getElementById('modalConfirmLoadBtn'); const modalCancelLoadBtn = document.getElementById('modalCancelLoadBtn'); const modalProjectPathInput = document.getElementById('modalProjectPath');
+closeModalBtn.onclick = () => loadProjectModal.style.display = 'none'; modalCancelLoadBtn.onclick = () => loadProjectModal.style.display = 'none'; window.onclick = (event) => { if (event.target == loadProjectModal) loadProjectModal.style.display = 'none'; }
+modalConfirmLoadBtn.addEventListener('click', () => {
+const projectPath = modalProjectPathInput.value;
+if (projectPath && projectPath.trim() !== "") {
+currentProjectName = projectPath.split('\\').pop().split('/').pop() || "Loaded Project"; updateTitle(); appendToConsole(`Loading project: ${projectPath}`, 'INFO');
+fileList.innerHTML = ''; const newFiles = [`${projectPath}\\file1.pts`, `${projectPath}\\file2.pts`, `${projectPath}\\module\\main.pts`]; let firstNewFileDiv = null;
+newFiles.forEach((fileName, index) => { const fileDiv = document.createElement('div'); fileDiv.className = 'file-item p-1.5 rounded-md cursor-pointer text-gray-700'; fileDiv.textContent = fileName; fileDiv.onclick = () => { loadFileContent(fileName); highlightActiveFile(fileDiv); }; fileList.appendChild(fileDiv); if (index === 0) firstNewFileDiv = fileDiv; });
+if (firstNewFileDiv) { loadFileContent(firstNewFileDiv.textContent); highlightActiveFile(firstNewFileDiv); } else { editor.setValue(`// Project ${currentProjectName} loaded. No files to display initially.`); symbolList.innerHTML = '<p class="text-gray-500 text-xs p-1">No files in project or project empty.</p>'; currentFileSymbols = []; }
+loadProjectModal.style.display = 'none'; modalProjectPathInput.value = '';
+} else { appendToConsole('Project path cannot be empty in modal.', 'WARN'); const tempAlert = document.createElement('div'); tempAlert.textContent = 'Please enter a project path.'; tempAlert.style.cssText = 'position:fixed; top:10px; left:50%; transform:translateX(-50%); background:red; color:white; padding:10px; border-radius:5px; z-index:2000;'; document.body.appendChild(tempAlert); setTimeout(() => tempAlert.remove(), 3000); }
+});
+document.getElementById('clearConsoleBtn').addEventListener('click', () => {
+consoleOutput.value = '';
+appendToConsole('Console cleared.', 'INFO');
+});
+const outputResizer = document.getElementById('outputResizer'); const outputWindow = document.getElementById('outputWindow'); let initialOutputHeight, initialMouseY;
+outputResizer.addEventListener('mousedown', (e) => { e.preventDefault(); initialOutputHeight = outputWindow.offsetHeight; initialMouseY = e.clientY; document.addEventListener('mousemove', resizeOutput); document.addEventListener('mouseup', stopResizeOutput); });
+function resizeOutput(e) { const deltaY = e.clientY - initialMouseY; let newHeight = initialOutputHeight - deltaY; const minHeight = 100, maxHeight = window.innerHeight * 0.8; newHeight = Math.max(minHeight, Math.min(newHeight, maxHeight)); outputWindow.style.height = `${newHeight}px`; }
+function stopResizeOutput() { document.removeEventListener('mousemove', resizeOutput); document.removeEventListener('mouseup', stopResizeOutput); }
+const rightPanel = document.getElementById('rightPanel'); document.getElementById('menuToggleSolutionExplorer').addEventListener('click', () => { const isHidden = rightPanel.style.display === 'none'; rightPanel.style.display = isHidden ? 'flex' : 'none'; appendToConsole(`Solution Explorer ${isHidden ? 'shown' : 'hidden'}.`, 'DEBUG'); });
+document.getElementById('menuToggleOutputWindow').addEventListener('click', () => { const isHidden = outputWindow.style.display === 'none'; outputWindow.style.display = isHidden ? 'flex' : 'none'; outputResizer.style.display = isHidden ? 'block' : 'none';appendToConsole(`Output Panel ${isHidden ? 'shown' : 'hidden'}.`, 'DEBUG'); });
+
+appendToConsole("Welcome to the SemDB IDE Console!", 'LOG');
+appendToConsole("help", 'CMD');
+appendToConsole("Available: help, clear, run_script, get_active_file", 'RESULT');
+appendToConsole("get_active_file", 'CMD');
+if (firstFileDivToLoad) { appendToConsole(`Active file: ${firstFileDivToLoad.textContent}`, 'RESULT');}
+
+appendToConsole('SemDB IDE Initialized (Unified Console).', 'INFO');
+if (initialFiles.length === 0 && !firstFileDivToLoad) { appendToConsole('No project loaded. Use File > Load Project or File > Add File.', 'INFO'); }


### PR DESCRIPTION
## Summary
- add standalone Editor.cshtml page for SemDB IDE with Tailwind and CodeMirror
- move inline CSS and JS into `/wwwroot/css/editor.css` and `/wwwroot/js/editor.js`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d591efc4832dbd671dfc571e7069