### PR TITLE
Add compilation and error markers

### DIFF
--- a/Buffaly.Ontology.Portal/Pages/Editor.cshtml
+++ b/Buffaly.Ontology.Portal/Pages/Editor.cshtml
@@ -15,6 +15,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/dialog/dialog.css">
 
 <link rel="stylesheet" href="~/css/editor.css">
+<link rel="stylesheet" href="~/css/protoscript-workbench.css">
 </head>
 <body class="flex flex-col h-screen bg-gray-100 text-gray-800 font-sans antialiased">
 
@@ -35,6 +36,7 @@
 <div class="flex-grow flex p-1 gap-1 overflow-hidden">
 <section class="flex-grow flex flex-col bg-white p-1 rounded-md shadow border border-gray-200 min-w-0">
 <textarea id="codeEditor">// Welcome to SemDB IDE! // Load a project or add a file to start. </textarea>
+<input type="text" id="txtFileName" class="hidden">
 </section>
 <aside id="rightPanel" class="w-[320px] flex flex-col bg-white p-3 rounded-md shadow border border-gray-200 gap-2">
 <div class="flex border-b border-gray-300 mb-1">
@@ -42,11 +44,14 @@
 <button data-pane="right" data-tab="symbolsTab" class="tab-button right-tab-button">Symbols</button>
 </div>
 <div id="solutionExplorerTab" class="tab-content right-tab-content active flex flex-col flex-grow gap-2 overflow-hidden">
-<input type="search" id="searchFiles" placeholder="Search files..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
-<div id="fileList" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+<input type="search" id="txtProjectFileSearch" placeholder="Search files..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
+<div id="divProject" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+<input type="search" id="txtFileSearch" placeholder="Search recent files..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
+<div id="divSolution" class="overflow-y-auto text-xs space-y-0.5 pr-1"></div>
 </div>
-<div id="symbolsTab" class="tab-content right-tab-content flex flex-col flex-grow gap-2 overflow-hidden"> <input type="search" id="searchSymbols" placeholder="Search symbols..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
-<div id="symbolList" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"><p class="text-gray-500 text-xs p-1">Select a file to view its symbols.</p></div>
+<div id="symbolsTab" class="tab-content right-tab-content flex flex-col flex-grow gap-2 overflow-hidden"> <input type="search" id="txtSymbolSearch" placeholder="Search symbols..." class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500">
+<div id="divRecentSymbols" class="overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+<div id="divSymbolTable" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"><p class="text-gray-500 text-xs p-1">Select a file to view its symbols.</p></div>
 </div>
 </aside>
 </div>
@@ -58,21 +63,30 @@
 <button data-pane="bottom" data-tab="consoleContent" class="tab-button bottom-tab-button active">Console</button>
 <button data-pane="bottom" data-tab="chatContent" class="tab-button bottom-tab-button">Chat</button>
 <button id="clearConsoleBtn" class="ml-auto bg-red-500 hover:bg-red-600 text-white px-2 py-0.5 text-xs rounded-md font-medium focus:outline-none focus:ring-1 focus:ring-red-400 mb-1 self-center">Clear Console</button>
+<button id="btnMaximize" class="ml-2 bg-gray-200 hover:bg-gray-300 text-xs px-1 rounded">&#9650;</button>
+<button id="btnHalfize" class="bg-gray-200 hover:bg-gray-300 text-xs px-1 rounded">&#9633;</button>
+<button id="btnMinimize" class="bg-gray-200 hover:bg-gray-300 text-xs px-1 rounded">&#9660;</button>
 </div>
 <div class="flex-grow p-2 overflow-hidden">
 <div id="consoleContent" class="tab-content bottom-tab-content active bottom-panel-tab-content">
-<textarea id="consoleOutput" readonly class="bottom-panel-textarea" placeholder="Console output, command history, and results will appear here..."></textarea>
-<div class="immediate-input-area">
-<input type="text" id="immediateCommandInput" placeholder="Enter command...">
-<button id="runImmediateCmdBtn" class="bg-blue-600 hover:bg-blue-700 text-white rounded-md">Run</button>
-</div>
-</div>
+<textarea id="txtResults2" readonly class="bottom-panel-textarea" placeholder="Console output, command history, and results will appear here..."></textarea>
+            <div class="immediate-input-area flex items-center gap-1">
+                <input type="text" id="txtImmediate" placeholder="Enter command..." class="flex-grow">
+                <button id="runImmediateCmdBtn" class="bg-blue-600 hover:bg-blue-700 text-white rounded-md">Run</button>
+                <span id="txtTaggingProgress" class="ml-2 text-xs text-gray-500"></span>
+            </div>
+            <div id="divImmediateHistory" class="overflow-y-auto text-xs mt-1 max-h-24"></div>
+        </div>
 <div id="chatContent" class="tab-content bottom-tab-content bottom-panel-tab-content"><p class="text-gray-500 text-xs p-2">Chat functionality placeholder.</p></div>
 </div>
 </footer>
 <script src="~/js/editor.js"></script>
+<script src="/JsonWs/ProtoScript.Extensions.ProtoScriptWorkbench.ashx.js?v=2"></script>
+<script src="~/js/protoscript-workbench.js"></script>
 
-<div id="loadProjectModal" class="modal"><div class="modal-content"><div class="modal-header"><span class="close-button" id="closeModalBtn">&times;</span><h2 class="text-lg font-semibold">Load Project</h2></div><div class="py-4"><label for="modalProjectPath" class="block text-sm font-medium text-gray-700 mb-1">Project File Path (.pts)</label><input type="text" id="modalProjectPath" placeholder="C:\path\to\your\project.pts" class="w-full bg-gray-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"><p class="text-xs text-gray-500 mt-1">Enter the full path to your project file.</p></div><div class="modal-footer"><button id="modalCancelLoadBtn" class="px-3 py-1.5 text-sm bg-gray-200 hover:bg-gray-300 rounded-md mr-2">Cancel</button><button id="modalConfirmLoadBtn" class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Load</button></div></div></div>
+<div id="loadProjectModal" class="modal"><div class="modal-content"><div class="modal-header"><span class="close-button" id="closeModalBtn">&times;</span><h2 class="text-lg font-semibold">Load Project</h2></div><div class="py-4"><label for="txtSolution" class="block text-sm font-medium text-gray-700 mb-1">Project File Path (.pts)</label><input type="text" id="txtSolution" placeholder="C:\path\to\your\project.pts" class="w-full bg-gray-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"><p class="text-xs text-gray-500 mt-1">Enter the full path to your project file.</p></div><div class="modal-footer"><button id="modalCancelLoadBtn" class="px-3 py-1.5 text-sm bg-gray-200 hover:bg-gray-300 rounded-md mr-2">Cancel</button><button id="modalConfirmLoadBtn" class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Load</button></div></div></div>
+
+<div id="addFileModal" class="modal"><div class="modal-content"><div class="modal-header"><span class="close-button" id="closeAddFileModalBtn">&times;</span><h2 class="text-lg font-semibold">Add New File</h2></div><div class="py-4"><label for="newFileName" class="block text-sm font-medium text-gray-700 mb-1">File Name</label><input type="text" id="newFileName" placeholder="Example.pts" class="w-full bg-gray-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"><p id="addFileError" class="text-xs text-red-600 mt-1 hidden">Please provide a valid file name.</p></div><div class="modal-footer"><button id="modalCancelAddFileBtn" class="px-3 py-1.5 text-sm bg-gray-200 hover:bg-gray-300 rounded-md mr-2">Cancel</button><button id="modalConfirmAddFileBtn" class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Add File</button></div></div></div>
 
 </body>
 </html>

--- a/Buffaly.Ontology.Portal/wwwroot/js/editor.js
+++ b/Buffaly.Ontology.Portal/wwwroot/js/editor.js
@@ -1,22 +1,108 @@
-const consoleOutput = document.getElementById("consoleOutput"); // Unified console output
-const immediateCommandInput = document.getElementById("immediateCommandInput");
-const runImmediateCmdBtn = document.getElementById("runImmediateCmdBtn");
-const headerProjectName = document.getElementById("headerProjectName");
-const fileList = document.getElementById("fileList");
-const symbolList = document.getElementById("symbolList");
-const searchFilesInput = document.getElementById("searchFiles");
-const searchSymbolsInput = document.getElementById("searchSymbols");
-let editor;
-let currentProjectName = "Untitled Project";
-let currentFileSymbols = [];
+	const consoleOutput = document.getElementById("txtResults2"); // Unified console output
+	const immediateCommandInput = document.getElementById("txtImmediate");
+	const runImmediateCmdBtn = document.getElementById("runImmediateCmdBtn");
+	const headerProjectName = document.getElementById("headerProjectName");
+	const fileList = document.getElementById("divProject");
+	const symbolList = document.getElementById("divSymbolTable");
+	const searchFilesInput = document.getElementById("txtProjectFileSearch");
+	const searchSymbolsInput = document.getElementById("txtSymbolSearch");
+	const fileHistoryList = document.getElementById("divSolution");
+	const searchHistoryInput = document.getElementById("txtFileSearch");
+	const immediateHistoryDiv = document.getElementById("divImmediateHistory");
+	const taggingProgressSpan = document.getElementById("txtTaggingProgress");
+	const btnMaximize = document.getElementById("btnMaximize");
+	const btnHalfize = document.getElementById("btnHalfize");
+	const btnMinimize = document.getElementById("btnMinimize");
 
-function updateTitle() {
+	let recentNavigations = [];
+	let selectedSymbolIdx = -1;
+	let filteredSymbols = [];
+	let selectedProjectFileIdx = -1;
+	let filteredProjectFiles = [];
+
+	const LocalSettings = JSON.parse(localStorage.getItem("EditorSettings") || "{}");
+	if (!LocalSettings.FileHistory) LocalSettings.FileHistory = [];
+	if (!LocalSettings.ImmediateHistory) LocalSettings.ImmediateHistory = [];
+	if (!LocalSettings.WindowSize) LocalSettings.WindowSize = "Halfize";
+	let sLastSaved = null;
+	let editor;
+	let sessionKey = null;
+	let bIsTagging = false;
+	let timerUpdate = null;
+	let currentProjectName = "Untitled Project";
+	let currentFileSymbols = [];
+
+	function updateTitle() {
 	document.title = `SemDB IDE - ${currentProjectName}`;
 	headerProjectName.textContent = `- ${currentProjectName}`;
 }
 updateTitle();
 
-function appendToConsole(message, type = "LOG") {
+	function saveLocalSettings() {
+localStorage.setItem("EditorSettings", JSON.stringify(LocalSettings));
+}
+
+	function queueFront(arr, item, max) {
+	const idx = arr.findIndex(x => JSON.stringify(x) === JSON.stringify(item));
+	if (idx !== -1) arr.splice(idx, 1);
+arr.unshift(item);
+	if (arr.length > max) arr.pop();
+	return arr;
+}
+
+	function getRelativePath(root, path) {
+	return path.toLowerCase().startsWith(root.toLowerCase() + "\\") ? path.substring(root.length + 1) : path;
+}
+
+	function createFileItem(fullPath, displayPath) {
+	const fileDiv = document.createElement("div");
+fileDiv.className = "file-item p-1.5 rounded-md cursor-pointer text-gray-700";
+fileDiv.textContent = displayPath || fullPath;
+fileDiv.title = fullPath;
+fileDiv.onclick = () => {
+document.getElementById("txtFileName").value = fullPath;
+OnLoadFile();
+highlightActiveFile(fileDiv);
+};
+	return fileDiv;
+}
+
+	function addFileToHistory(file) {
+	let existing = LocalSettings.FileHistory.find(x => x.File && x.File.toLowerCase() === file.toLowerCase());
+	if (!existing) existing = { File: file };
+LocalSettings.FileHistory = queueFront(LocalSettings.FileHistory, existing, 50);
+saveLocalSettings();
+	return existing;
+}
+
+	function bindFileHistory() {
+	if (!fileHistoryList) return;
+fileHistoryList.innerHTML = "";
+LocalSettings.FileHistory.forEach(item => {
+	const div = createFileItem(item.File);
+fileHistoryList.appendChild(div);
+});
+}
+
+	function bindImmediateHistory() {
+	if (!immediateHistoryDiv) return;
+       immediateHistoryDiv.innerHTML = "";
+       LocalSettings.ImmediateHistory.forEach(cmd => {
+	const div = document.createElement("div");
+               div.className = "cursor-pointer px-1 hover:bg-gray-100";
+               div.textContent = cmd;
+               div.onclick = () => {
+                       immediateCommandInput.value = cmd;
+               };
+               immediateHistoryDiv.appendChild(div);
+       });
+}
+
+	function isCurrentFileSaved() {
+	return !sLastSaved || editor.getValue() === sLastSaved;
+}
+
+	function appendToConsole(message, type = "LOG") {
 	const timestamp = new Date().toLocaleTimeString();
 	let prefix = "";
 	if (type === "CMD") {
@@ -33,19 +119,210 @@ function appendToConsole(message, type = "LOG") {
 	// For 'LOG', no specific prefix, just the timestamped message
 
 	consoleOutput.value += `[${timestamp}] ${prefix}${message}\n`;
-	consoleOutput.scrollTop = consoleOutput.scrollHeight;
+        consoleOutput.scrollTop = consoleOutput.scrollHeight;
 }
 
-editor = CodeMirror.fromTextArea(document.getElementById("codeEditor"), {
-	lineNumbers: true,
-	mode: "javascript",
-	theme: "neat",
-	matchBrackets: true,
-	autoCloseBrackets: true,
-	lineWrapping: true,
+	function ClearOutput() {
+       consoleOutput.value = "";
+}
+
+	function Output(msg) {
+	appendToConsole(msg, "RESULT");
+}
+
+	function isLetter(ch) {
+	return ch.length === 1 && /[a-z]/i.test(ch);
+}
+
+	function isNumber(ch) {
+	return ch.length === 1 && /\d/.test(ch);
+}
+
+	function OnPredictNextLine(cm) {
+	const doc = editor.getDoc();
+	const cursor = doc.getCursor();
+	const pos = doc.indexFromPos(cursor);
+	const before = doc.getRange({ line: 0, ch: 0 }, cursor);
+	const after = doc.getRange(cursor, { line: Infinity, ch: Infinity });
+	appendToConsole("Thinking", "INFO");
+	ProtoScriptWorkbench.PredictNextLine(pos, function(res) {
+	appendToConsole(res.length + " results found", "INFO");
+	if (res && res.length > 0) {
+	const newPart = StringUtil.ReplaceAll(res[0], "\n", "\r\n");
+	editor.setValue(before + "\r\n" + newPart + "\r\n" + after);
+}
+});
+}
+
+	function OnSuggest(cm) {
+	const cursor = cm.getCursor();
+	const lineText = cm.getLine(cursor.line).substr(0, cursor.ch);
+	if (StringUtil.InString(lineText, "//")) return null;
+	const pos = cm.indexFromPos(cursor);
+	let results = [];
+	let offset = lineText.length;
+	let search = "";
+	const lastSavedOffset = GetCode().length - (sLastSaved ? sLastSaved.length : 0);
+	if (!StringUtil.IsEmpty(lineText)) {
+	let type = "";
+for (let i = lineText.length - 1; i >= 0; i--) {
+	const ch = lineText[i];
+	if (isLetter(ch) || isNumber(ch) || ch === "_") {
+search = ch + search;
+offset--;
+} else if (ch === ".") {
+type = "SubObject";
+break;
+} else if (ch === "(" || ch === ",") {
+type = "Parameter";
+break;
+} else {
+type = "Symbol";
+break;
+}
+}
+	let res2 = [];
+	if (!StringUtil.IsEmpty(search) && ["Symbol", "Parameter"].includes(type)) {
+res2 = ProtoScriptWorkbench.GetSymbolsAtCursor(LocalSettings.Solution, LocalSettings.File, pos - lastSavedOffset) || [];
+res2 = res2.filter(x => StringUtil.StartsWith(x.SymbolName, search));
+}
+	let res3 = [];
+	if (type === "SubObject" && !StringUtil.IsEmpty(lineText)) {
+res3 = ProtoScriptWorkbench.Suggest(LocalSettings.Solution, lineText, pos) || [];
+}
+	let res = [];
+	if (!StringUtil.IsEmpty(search) && ["Symbol", "Parameter"].includes(type)) {
+res = Symbols.filter(x => StringUtil.StartsWith(x.SymbolName, search));
+}
+for (let i = 0; i < res3.length; i++) results.push(res3[i].SymbolName);
+for (let i = 0; i < res2.length; i++) results.push(res2[i].SymbolName);
+for (let i = 0; i < res.length && i < 10; i++) results.push(res[i].SymbolName);
+}
+	if (results.length > 0) {
+	return {
+list: results,
+from: CodeMirror.Pos(cursor.line, offset),
+to: CodeMirror.Pos(cursor.line, offset + search.length)
+};
+}
+	return null;
+}
+
+	const ExcludedIntelliSenseTriggerKeys = {
+"8": "backspace",
+"9": "tab",
+"13": "enter",
+"16": "shift",
+"17": "ctrl",
+"18": "alt",
+"19": "pause",
+"20": "capslock",
+"27": "escape",
+"33": "pageup",
+"34": "pagedown",
+"35": "end",
+"36": "home",
+"37": "left",
+"38": "up",
+"39": "right",
+"40": "down",
+"45": "insert",
+"46": "delete",
+"91": "left window key",
+"92": "right window key",
+"93": "select",
+"107": "add",
+"109": "subtract",
+"110": "decimal point",
+"111": "divide",
+"112": "f1",
+"113": "f2",
+"114": "f3",
+"115": "f4",
+"116": "f5",
+"117": "f6",
+"118": "f7",
+"119": "f8",
+"120": "f9",
+"121": "f10",
+"122": "f11",
+"123": "f12",
+"144": "numlock",
+"145": "scrolllock",
+"186": "semicolon",
+"187": "equalsign",
+"188": "comma",
+"189": "dash",
+"191": "slash",
+"192": "graveaccent",
+"220": "backslash",
+"222": "quote"
+};
+
+	editor = CodeMirror.fromTextArea(document.getElementById("codeEditor"), {
+mode: "text/x-csharp",
+indentWithTabs: true,
+smartIndent: true,
+lineNumbers: true,
+matchBrackets: true,
+autoCloseBrackets: true,
+lineWrapping: true,
+lineSeparator: "\r\n",
+newline: "crlf",
+extraKeys: { "Ctrl-Space": "autocomplete", "Ctrl-Enter": OnEnter, "Alt-Space": OnPredictNextLine },
+hintOptions: { hint: OnSuggest, completeSingle: false },
+gutters: ["gutter-error", "breakpoints", "CodeMirror-linenumbers"]
+});
+	editor.on("gutterClick", function(cm, n) {
+	const info = cm.lineInfo(n);
+	if (info.gutterMarkers) {
+cm.setGutterMarker(n, "breakpoints", null);
+RemoveBreakPoint(info);
+} else {
+cm.setGutterMarker(n, "breakpoints", makeBreakpoint());
+SetBreakPoint(info);
+}
+});
+	editor.on("keyup", function(cm, event) {
+	if (!cm.state.completionActive && !ExcludedIntelliSenseTriggerKeys[(event.keyCode || event.which).toString()]) {
+CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
+}
 });
 
-function switchTab(panePrefix, tabIdToShow) {
+function makeBreakpoint() {
+	const marker = document.createElement("div");
+	marker.className = "breakpoint";
+	marker.innerHTML = "●";
+	return marker;
+}
+bindFileHistory();
+bindImmediateHistory();
+
+	function OnMaximize() {
+outputWindow.style.height = '90vh';
+LocalSettings.WindowSize = 'Maximize';
+saveLocalSettings();
+}
+
+	function OnHalfize() {
+outputWindow.style.height = '50vh';
+LocalSettings.WindowSize = 'Halfize';
+saveLocalSettings();
+}
+
+	function OnMinimize() {
+outputWindow.style.height = '150px';
+LocalSettings.WindowSize = 'Minimize';
+saveLocalSettings();
+}
+
+	function AdjustWindowSizes() {
+	if (LocalSettings.WindowSize === 'Maximize') OnMaximize();
+else if (LocalSettings.WindowSize === 'Minimize') OnMinimize();
+else OnHalfize();
+}
+
+	function switchTab(panePrefix, tabIdToShow) {
 	document
 		.querySelectorAll(`button[data-pane='${panePrefix}']`)
 		.forEach((button) => {
@@ -84,14 +361,14 @@ document.querySelectorAll(".tab-button").forEach((button) => {
 switchTab("right", "solutionExplorerTab");
 switchTab("bottom", "consoleContent");
 
-function highlightActiveFile(selectedItem) {
+	function highlightActiveFile(selectedItem) {
 	document
-		.querySelectorAll("#fileList .file-item")
+.querySelectorAll("#divProject .file-item")
 		.forEach((item) => item.classList.remove("active"));
 	if (selectedItem) selectedItem.classList.add("active");
 }
 
-function parseAndDisplaySymbols(fileName, codeContent) {
+	function parseAndDisplaySymbols(fileName, codeContent) {
 	currentFileSymbols = [];
 	symbolList.innerHTML = "";
 	const functionRegex = /function\s+([a-zA-Z0-9_]+)\s*\(/g;
@@ -172,7 +449,7 @@ function parseAndDisplaySymbols(fileName, codeContent) {
 	}
 }
 
-function getSymbolIcon(type) {
+	function getSymbolIcon(type) {
 	let iconSvg = "";
 	switch (type) {
 		case "function":
@@ -193,7 +470,7 @@ function getSymbolIcon(type) {
 	return iconSvg;
 }
 
-function renderSymbolList(symbolsToRender) {
+	function renderSymbolList(symbolsToRender) {
 	symbolList
 		.querySelectorAll(".symbol-item, .no-symbols-message")
 		.forEach((el) => el.remove());
@@ -254,10 +531,242 @@ function renderSymbolList(symbolsToRender) {
 				);
 			}
 		};
-		symbolList.appendChild(item);
+               symbolList.appendChild(item);
+       });
+
+       filteredSymbols = symbolsToRender.slice();
+       selectedSymbolIdx = -1;
+}
+
+async function OnLoadProject() {
+	const projectPath = document.getElementById("txtSolution").value.trim();
+	if (!projectPath) {
+	appendToConsole("Project path cannot be empty.", "WARN");
+	return;
+}
+	appendToConsole(`Loading project: ${projectPath}`, "INFO");
+	const root = projectPath.substring(0, projectPath.lastIndexOf("\\"));
+	const files = await new Promise(r => ProtoScriptWorkbench.LoadProject(projectPath, r));
+fileList.innerHTML = "";
+	let firstDiv = null;
+files.forEach((f, i) => {
+	const div = createFileItem(f, getRelativePath(root, f));
+fileList.appendChild(div);
+	if (i === 0) firstDiv = div;
+});
+filterProjectFiles();
+currentProjectName = projectPath.split("\\").pop().split("/").pop();
+updateTitle();
+LocalSettings.Solution = projectPath;
+saveLocalSettings();
+	let fileToOpen = LocalSettings.File || (files.length > 0 ? files[0] : null);
+	if (fileToOpen) {
+document.getElementById("txtFileName").value = fileToOpen;
+await OnLoadFile();
+	const item = Array.from(fileList.querySelectorAll('.file-item')).find(d => d.title && d.title.toLowerCase() === fileToOpen.toLowerCase());
+	if (item) highlightActiveFile(item);
+}
+}
+
+async function OnLoadFile() {
+	const file = document.getElementById("txtFileName").value;
+	if (!isCurrentFileSaved() && !confirm("You have unsaved changes, continue?")) return;
+	const content = await new Promise(r => ProtoScriptWorkbench.LoadFile(LocalSettings.Solution, file, r));
+	editor.setValue(content);
+sLastSaved = content;
+parseAndDisplaySymbols(file, content);
+LocalSettings.File = file;
+addFileToHistory(file);
+bindFileHistory();
+saveLocalSettings();
+}
+
+async function SaveCurrentFile() {
+	const code = editor.getValue();
+sLastSaved = code;
+await new Promise(r => ProtoScriptWorkbench.SaveCurrentCode(LocalSettings.Solution, LocalSettings.File, code, r));
+	appendToConsole("File saved.", "INFO");
+}
+
+	function OnSaveCurrentFile() {
+SaveCurrentFile();
+}
+
+	function clearErrors() {
+	editor.clearGutter("gutter-error");
+}
+
+	function makeMarker(msg) {
+	const marker = document.createElement("div");
+	marker.classList.add("error-marker");
+	marker.innerHTML = "&nbsp;";
+	const error = document.createElement("div");
+error.innerHTML = msg;
+error.classList.add("error-message");
+	marker.appendChild(error);
+	return marker;
+}
+
+	function highlightError(error) {
+	if (error && error.Info && error.Info.File && LocalSettings.File &&
+error.Info.File.toLowerCase() === LocalSettings.File.toLowerCase()) {
+	const line = editor.posFromIndex(error.Info.StartingOffset).line;
+	const marker = makeMarker(`(Error ${error.Type}) ${error.Message}`);
+	editor.setGutterMarker(line, "gutter-error", marker);
+}
+}
+
+async function CompileCode() {
+try {
+	if (!isCurrentFileSaved())
+await SaveCurrentFile();
+	appendToConsole("Compilation starting...", "INFO");
+	const code = editor.getValue();
+	ProtoScriptWorkbench.CompileCode.onErrorReceived = () => {
+	appendToConsole("Compilation failed", "ERROR");
+};
+	ProtoScriptWorkbench.CompileCodeWithProject.onErrorReceived = (err) => {
+	appendToConsole("Compilation failed", "ERROR");
+	appendToConsole(JSON.stringify(err), "ERROR");
+};
+	const projectFile = LocalSettings.Solution;
+	if (projectFile) {
+clearErrors();
+await new Promise((resolve) => {
+	ProtoScriptWorkbench.CompileCodeWithProject.Serialize = { Info: true };
+	ProtoScriptWorkbench.CompileCodeWithProject(code, projectFile, (res) => {
+	let first = true;
+res.forEach((err) => {
+	if (first && err.Info) {
+first = false;
+NavigateTo(err.Info);
+}
+setTimeout(() => highlightError(err), 1000);
+	if (err.Info)
+	appendToConsole(`${err.Message}, ${err.Info.File}`, "ERROR");
+else
+	appendToConsole(err.Message, "ERROR");
+});
+	appendToConsole(`${res.length} errors`, "INFO");
+resolve();
+});
+});
+} else {
+	ProtoScriptWorkbench.CompileCode(code, (res) => {
+clearErrors();
+res.forEach((err) => highlightError(err));
+	appendToConsole(`${res.length} errors`, "INFO");
+});
+}
+	appendToConsole("Compilation finished", "INFO");
+} catch (err) {
+	appendToConsole(err.toString(), "ERROR");
+}
+}
+
+	function ScrollToLine(line) {
+	editor.scrollIntoView({ line, ch: 0 }, 200);
+}
+
+	function ScrollTo(info) {
+	if (typeof info.line === "number") {
+		ScrollToLine(info.line - 1);
+		editor.setCursor({ line: info.line - 1, ch: 0 });
+	} else if (typeof info.StartingOffset === "number") {
+		const pos = editor.posFromIndex(info.StartingOffset);
+		ScrollToLine(pos.line);
+		editor.setCursor(pos);
+	}
+}
+
+	function bindRecentNavigations() {
+	const container = document.getElementById("divRecentSymbols");
+	if (!container) return;
+	container.innerHTML = "";
+	recentNavigations.forEach((nav) => {
+		const div = document.createElement("div");
+		div.className = "symbol-item";
+		div.textContent = nav.SymbolName;
+		div.onclick = () => NavigateTo(nav, nav.SymbolName);
+		container.appendChild(div);
 	});
 }
 
+	function NavigateTo(info, symbolName) {
+	if (symbolName) {
+info.SymbolName = symbolName;
+recentNavigations = queueFront(recentNavigations, info, 5);
+}
+document.getElementById("txtFileName").value = info.File;
+OnLoadFile().then(() => {
+ScrollTo(info);
+bindRecentNavigations();
+});
+}
+
+	function startSymbolSearch() {
+switchTab("right", "symbolsTab");
+searchSymbolsInput.value = "";
+searchSymbolsInput.dispatchEvent(new Event("input"));
+searchSymbolsInput.focus();
+}
+
+	function selectNextSymbol() {
+	if (selectedSymbolIdx < filteredSymbols.length - 1) selectedSymbolIdx++;
+updateSymbolSelection();
+}
+
+	function selectPreviousSymbol() {
+	if (selectedSymbolIdx > 0) selectedSymbolIdx--;
+updateSymbolSelection();
+}
+
+	function updateSymbolSelection() {
+	const items = symbolList.querySelectorAll(".symbol-item");
+items.forEach((el) => el.classList.remove("active"));
+	if (selectedSymbolIdx >= 0 && items[selectedSymbolIdx]) {
+items[selectedSymbolIdx].classList.add("active");
+items[selectedSymbolIdx].scrollIntoView({ block: "nearest" });
+}
+}
+
+	function navigateToSelectedSymbol() {
+	if (selectedSymbolIdx >= 0 && filteredSymbols[selectedSymbolIdx]) {
+NavigateTo({ File: LocalSettings.File, line: filteredSymbols[selectedSymbolIdx].line }, filteredSymbols[selectedSymbolIdx].name);
+}
+}
+
+	function startProjectSearch() {
+switchTab("right", "solutionExplorerTab");
+searchFilesInput.value = "";
+filterProjectFiles();
+searchFilesInput.focus();
+}
+
+	function updateProjectFileSelection() {
+	const items = filteredProjectFiles;
+fileList.querySelectorAll(".file-item").forEach((el) => el.classList.remove("active"));
+	if (selectedProjectFileIdx >= 0 && items[selectedProjectFileIdx]) {
+items[selectedProjectFileIdx].classList.add("active");
+items[selectedProjectFileIdx].scrollIntoView({ block: "nearest" });
+}
+}
+
+	function selectNextProjectFile() {
+	if (selectedProjectFileIdx < filteredProjectFiles.length - 1) selectedProjectFileIdx++;
+updateProjectFileSelection();
+}
+
+	function selectPreviousProjectFile() {
+	if (selectedProjectFileIdx > 0) selectedProjectFileIdx--;
+updateProjectFileSelection();
+}
+
+	function navigateToSelectedProjectFile() {
+	if (selectedProjectFileIdx >= 0 && filteredProjectFiles[selectedProjectFileIdx]) {
+filteredProjectFiles[selectedProjectFileIdx].click();
+}
+}
 searchSymbolsInput.addEventListener("input", (e) => {
 	const searchTerm = e.target.value.toLowerCase();
 	const fileTitleElement = symbolList.querySelector(
@@ -270,10 +779,22 @@ searchSymbolsInput.addEventListener("input", (e) => {
 	const filteredSymbols = currentFileSymbols.filter((symbol) =>
 		symbol.name.toLowerCase().includes(searchTerm),
 	);
-	renderSymbolList(filteredSymbols);
+renderSymbolList(filteredSymbols);
+});
+searchSymbolsInput.addEventListener("keydown", (e) => {
+	if (e.key === "ArrowDown") {
+selectNextSymbol();
+e.preventDefault();
+} else if (e.key === "ArrowUp") {
+selectPreviousSymbol();
+e.preventDefault();
+} else if (e.key === "Enter") {
+navigateToSelectedSymbol();
+e.preventDefault();
+}
 });
 
-function loadFileContent(fileName) {
+	function loadFileContent(fileName) {
 	appendToConsole(`Loading file: ${fileName}`, "INFO");
 	let mockContent = `// Content for ${fileName}\n\n// ProtoScript code goes here...\n\n`;
 	if (fileName.includes("Annotations.pts")) {
@@ -292,14 +813,14 @@ function loadFileContent(fileName) {
 	parseAndDisplaySymbols(fileName, mockContent);
 }
 
-const initialFiles = [
+	const initialFiles = [
 	"..\\NL_Project_1.0.1\\Annotations.pts",
 	"..\\NL_Project_1.0.1\\Articles.pts",
 	"..\\NL_Project_1.0.1\\Base.pts",
 	"..\\NL_Project_1.0.1\\Utils.pts",
 	"..\\NL_Project_1.0.1\\Main.pts",
 ];
-let firstFileDivToLoad = null;
+	let firstFileDivToLoad = null;
 initialFiles.forEach((fileName, index) => {
 	const fileDiv = document.createElement("div");
 	fileDiv.className =
@@ -309,108 +830,161 @@ initialFiles.forEach((fileName, index) => {
 		loadFileContent(fileName);
 		highlightActiveFile(fileDiv);
 	};
-	fileList.appendChild(fileDiv);
+fileList.appendChild(fileDiv);
 	if (index === 0) {
 		firstFileDivToLoad = fileDiv;
 	}
 });
-if (firstFileDivToLoad) {
-	loadFileContent(firstFileDivToLoad.textContent);
-	highlightActiveFile(firstFileDivToLoad);
+	if (firstFileDivToLoad) {
+loadFileContent(firstFileDivToLoad.textContent);
+highlightActiveFile(firstFileDivToLoad);
+}
+filterProjectFiles();
+
+	function filterProjectFiles() {
+	const searchTerm = searchFilesInput.value.toLowerCase();
+filteredProjectFiles = [];
+fileList.querySelectorAll(".file-item").forEach((item) => {
+	const match = item.textContent.toLowerCase().includes(searchTerm);
+item.style.display = match ? "block" : "none";
+	if (match) filteredProjectFiles.push(item);
+});
+selectedProjectFileIdx = -1;
 }
 
-searchFilesInput.addEventListener("input", (e) => {
-	const searchTerm = e.target.value.toLowerCase();
-	document.querySelectorAll("#fileList .file-item").forEach((item) => {
-		item.style.display = item.textContent.toLowerCase().includes(searchTerm)
-			? "block"
-			: "none";
-	});
+searchFilesInput.addEventListener("input", () => {
+filterProjectFiles();
+});
+searchFilesInput.addEventListener("keydown", (e) => {
+	if (e.key === "ArrowDown") {
+selectNextProjectFile();
+e.preventDefault();
+} else if (e.key === "ArrowUp") {
+selectPreviousProjectFile();
+e.preventDefault();
+} else if (e.key === "Enter") {
+navigateToSelectedProjectFile();
+e.preventDefault();
+}
+});
+	if (searchHistoryInput)
+searchHistoryInput.addEventListener("input", (e) => {
+	const term = e.target.value.toLowerCase();
+document.querySelectorAll("#divSolution .file-item").forEach((item) => {
+item.style.display = item.textContent.toLowerCase().includes(term) ? "block" : "none";
+});
 });
 
 document.getElementById("menuLoadProject").addEventListener("click", () => {
-	document.getElementById("loadProjectModal").style.display = "block";
+document.getElementById("loadProjectModal").style.display = "block";
 	appendToConsole("Opened Load Project dialog.", "INFO");
 });
+
 document.getElementById("menuAddFile").addEventListener("click", () => {
-	const newFileName = prompt("Enter new file name (e.g., myFile.pts):");
-	if (newFileName && newFileName.trim() !== "") {
-		const fileDiv = document.createElement("div");
-		fileDiv.className =
-			"file-item p-1.5 rounded-md cursor-pointer text-gray-700";
-		fileDiv.textContent = newFileName;
-		fileDiv.onclick = () => {
-			loadFileContent(newFileName);
-			highlightActiveFile(fileDiv);
-		};
-		fileList.appendChild(fileDiv);
-		appendToConsole(`Added file: ${newFileName}`, "INFO");
-		loadFileContent(newFileName);
-		highlightActiveFile(fileDiv);
-	} else if (newFileName !== null) {
-		appendToConsole("File name cannot be empty.", "WARN");
-	}
-});
-document.getElementById("menuCompile").addEventListener("click", () => {
-	appendToConsole("Compile action triggered.", "INFO");
-	const code = editor.getValue();
-	if (code.trim() === "") {
-		appendToConsole("Editor is empty. Nothing to compile.", "WARN");
-		return;
-	}
-	appendToConsole("Compilation started...", "INFO");
-	setTimeout(
-		() => appendToConsole("Compilation finished (simulated).", "INFO"),
-		1500,
-	);
+addFileModal.style.display = "block";
+addFileError.classList.add("hidden");
+modalNewFileNameInput.value = "";
+	appendToConsole("Opened Add File dialog.", "INFO");
 });
 
-runImmediateCmdBtn.addEventListener("click", () => {
+document.getElementById("menuSaveFile").addEventListener("click", OnSaveCurrentFile);
+document.getElementById("menuCompile").addEventListener("click", CompileCode);
+
+	function OnProcessImmediate() {
 	const command = immediateCommandInput.value.trim();
 	if (command === "") {
-		appendToConsole("No command entered.", "WARN");
-		return;
-	}
+	appendToConsole("No command entered.", "WARN");
+               return;
+       }
 	appendToConsole(command, "CMD");
-	if (command.toLowerCase() === "help") {
-		appendToConsole(
-			"Available: help, clear, run_script, get_active_file",
-			"RESULT",
-		);
-	} else if (command.toLowerCase() === "clear") {
-		consoleOutput.value = "";
-		appendToConsole("Console cleared.", "RESULT");
-	} else if (command.toLowerCase() === "run_script") {
-		appendToConsole("Interpreting current script in editor...", "LOG");
-		const code = editor.getValue();
-		if (code.trim() === "") {
-			appendToConsole("Editor is empty. Nothing to interpret.", "WARN");
-		} else {
-			setTimeout(() => {
-				appendToConsole(
-					"Interpretation finished (simulated). Result: OK",
-					"RESULT",
-				);
-			}, 1000);
-		}
-	} else if (command.toLowerCase() === "get_active_file") {
-		const activeFile = document.querySelector(
-			"#fileList .file-item.active",
-		);
-		if (activeFile) {
-			appendToConsole(`Active file: ${activeFile.textContent}`, "RESULT");
-		} else {
-			appendToConsole("No file is currently active.", "RESULT");
-		}
-	} else {
-		appendToConsole(`Simulating: ${command}`, "LOG");
-		setTimeout(
-			() =>
-				appendToConsole(`'${command}' executed. Output: OK`, "RESULT"),
-			500,
-		);
-	}
-	immediateCommandInput.value = "";
+	if (command.toLowerCase() === "clear") {
+               ClearOutput();
+	appendToConsole("Console cleared.", "RESULT");
+               immediateCommandInput.value = "";
+               return;
+       }
+	if (command.endsWith(")") && command.includes("(")) {
+               OnInterpretImmediate();
+       } else {
+               OnTagImmediate();
+       }
+       immediateCommandInput.value = "";
+}
+
+async function OnInterpretImmediate() {
+	if (!isCurrentFileSaved()) await SaveCurrentFile();
+	const project = LocalSettings.Solution;
+	const cmd = immediateCommandInput.value.trim();
+	const options = {
+               IncludeTypeOfs: document.getElementById("settingShowTypeOfs").checked,
+               Debug: document.getElementById("settingDebugMode").checked,
+               Resume: document.getElementById("settingResumeExecution").checked,
+               SessionKey: LocalSettings.Solution,
+       };
+       sessionKey = options.SessionKey;
+	appendToConsole("Interpreting...", "INFO");
+       LocalSettings.ImmediateHistory = queueFront(LocalSettings.ImmediateHistory, cmd, 50);
+       saveLocalSettings();
+       bindImmediateHistory();
+	ProtoScriptWorkbench.InterpretImmediate.onErrorReceived = (err) => {
+               Output(err.Error || JSON.stringify(err));
+	if (err.ErrorStatement) NavigateTo(err.ErrorStatement);
+       };
+       await new Promise((resolve) => {
+	ProtoScriptWorkbench.InterpretImmediate(project, cmd, options, (res) => {
+                       Output(res.Result || "");
+                       resolve();
+               });
+       });
+}
+
+async function OnTagImmediate() {
+	if (bIsTagging) {
+	ProtoScriptWorkbench.StopTagging(sessionKey);
+               bIsTagging = false;
+               clearInterval(timerUpdate);
+               taggingProgressSpan.textContent = "";
+               return;
+       }
+       bIsTagging = true;
+	if (!isCurrentFileSaved()) await SaveCurrentFile();
+	const cmd = immediateCommandInput.value.trim();
+	const project = LocalSettings.Solution;
+	const options = {
+               IncludeTypeOfs: document.getElementById("settingShowTypeOfs").checked,
+               Debug: document.getElementById("settingDebugMode").checked,
+               Resume: document.getElementById("settingResumeExecution").checked,
+               SessionKey: LocalSettings.Solution,
+       };
+       sessionKey = options.SessionKey;
+       LocalSettings.ImmediateHistory = queueFront(LocalSettings.ImmediateHistory, cmd, 50);
+       saveLocalSettings();
+       bindImmediateHistory();
+	ProtoScriptWorkbench.TagImmediate.onErrorReceived = (err) => {
+               clearInterval(timerUpdate);
+               bIsTagging = false;
+               Output(err.Error || JSON.stringify(err));
+	if (err.ErrorStatement) NavigateTo(err.ErrorStatement);
+       };
+       timerUpdate = setInterval(() => {
+	ProtoScriptWorkbench.GetTaggingProgress(sessionKey, (progress) => {
+	if (progress) taggingProgressSpan.textContent = `${progress.Iterations}: ${progress.CurrentInterpretation}`;
+               });
+       }, 1000);
+	ProtoScriptWorkbench.TagImmediate(cmd, project, options, (res) => {
+               bIsTagging = false;
+               clearInterval(timerUpdate);
+               taggingProgressSpan.textContent = "";
+	if (res.Result) Output(res.Result); else if (res.Error) { Output(res.Error); if (res.ErrorStatement) NavigateTo(res.ErrorStatement); }
+       });
+}
+
+runImmediateCmdBtn.addEventListener("click", OnProcessImmediate);
+immediateCommandInput.addEventListener("keydown", (e) => {
+	if (e.key === "Enter") {
+               OnProcessImmediate();
+               e.preventDefault();
+       }
 });
 
 ["settingShowTypeOfs", "settingDebugMode", "settingResumeExecution"].forEach(
@@ -432,80 +1006,67 @@ runImmediateCmdBtn.addEventListener("click", () => {
 			else if (id === "editRedo") editor.redo();
 		});
 });
-const findBtn = document.getElementById("editFind");
-if (findBtn)
+	const findBtn = document.getElementById("editFind");
+	if (findBtn)
 	findBtn.addEventListener("click", () => {
 		CodeMirror.commands.find(editor);
 		appendToConsole("Find dialog opened.", "DEBUG");
 	});
 
-const loadProjectModal = document.getElementById("loadProjectModal");
-const closeModalBtn = document.getElementById("closeModalBtn");
-const modalConfirmLoadBtn = document.getElementById("modalConfirmLoadBtn");
-const modalCancelLoadBtn = document.getElementById("modalCancelLoadBtn");
-const modalProjectPathInput = document.getElementById("modalProjectPath");
+	const loadProjectModal = document.getElementById("loadProjectModal");
+	const closeModalBtn = document.getElementById("closeModalBtn");
+	const modalConfirmLoadBtn = document.getElementById("modalConfirmLoadBtn");
+	const modalCancelLoadBtn = document.getElementById("modalCancelLoadBtn");
+	const modalProjectPathInput = document.getElementById("txtSolution");
+	const addFileModal = document.getElementById("addFileModal");
+	const closeAddFileModalBtn = document.getElementById("closeAddFileModalBtn");
+	const modalConfirmAddFileBtn = document.getElementById("modalConfirmAddFileBtn");
+	const modalCancelAddFileBtn = document.getElementById("modalCancelAddFileBtn");
+	const modalNewFileNameInput = document.getElementById("newFileName");
+	const addFileError = document.getElementById("addFileError");
 closeModalBtn.onclick = () => (loadProjectModal.style.display = "none");
 modalCancelLoadBtn.onclick = () => (loadProjectModal.style.display = "none");
 window.onclick = (event) => {
 	if (event.target == loadProjectModal)
 		loadProjectModal.style.display = "none";
 };
-modalConfirmLoadBtn.addEventListener("click", () => {
-	const projectPath = modalProjectPathInput.value;
-	if (projectPath && projectPath.trim() !== "") {
-		currentProjectName =
-			projectPath.split("\\").pop().split("/").pop() || "Loaded Project";
-		updateTitle();
-		appendToConsole(`Loading project: ${projectPath}`, "INFO");
-		fileList.innerHTML = "";
-		const newFiles = [
-			`${projectPath}\\file1.pts`,
-			`${projectPath}\\file2.pts`,
-			`${projectPath}\\module\\main.pts`,
-		];
-		let firstNewFileDiv = null;
-		newFiles.forEach((fileName, index) => {
-			const fileDiv = document.createElement("div");
-			fileDiv.className =
-				"file-item p-1.5 rounded-md cursor-pointer text-gray-700";
-			fileDiv.textContent = fileName;
-			fileDiv.onclick = () => {
-				loadFileContent(fileName);
-				highlightActiveFile(fileDiv);
-			};
-			fileList.appendChild(fileDiv);
-			if (index === 0) firstNewFileDiv = fileDiv;
-		});
-		if (firstNewFileDiv) {
-			loadFileContent(firstNewFileDiv.textContent);
-			highlightActiveFile(firstNewFileDiv);
-		} else {
-			editor.setValue(
-				`// Project ${currentProjectName} loaded. No files to display initially.`,
-			);
-			symbolList.innerHTML =
-				'<p class="text-gray-500 text-xs p-1">No files in project or project empty.</p>';
-			currentFileSymbols = [];
-		}
-		loadProjectModal.style.display = "none";
-		modalProjectPathInput.value = "";
-	} else {
-		appendToConsole("Project path cannot be empty in modal.", "WARN");
-		const tempAlert = document.createElement("div");
-		tempAlert.textContent = "Please enter a project path.";
-		tempAlert.style.cssText =
-			"position:fixed; top:10px; left:50%; transform:translateX(-50%); background:red; color:white; padding:10px; border-radius:5px; z-index:2000;";
-		document.body.appendChild(tempAlert);
-		setTimeout(() => tempAlert.remove(), 3000);
-	}
+modalConfirmLoadBtn.addEventListener("click", async () => {
+await OnLoadProject();
+loadProjectModal.style.display = "none";
+modalProjectPathInput.value = "";
+});
+closeAddFileModalBtn.onclick = () => (addFileModal.style.display = "none");
+modalCancelAddFileBtn.onclick = () => (addFileModal.style.display = "none");
+window.addEventListener("click", (e) => {
+	if (e.target === addFileModal) addFileModal.style.display = "none";
+});
+modalConfirmAddFileBtn.addEventListener("click", () => {
+	const newFileName = modalNewFileNameInput.value.trim();
+	if (!newFileName) {
+addFileError.classList.remove("hidden");
+	return;
+}
+addFileError.classList.add("hidden");
+	ProtoScriptWorkbench.CreateNewFile(LocalSettings.Solution, newFileName, (res) => {
+	if (res) {
+	const div = createFileItem(newFileName);
+fileList.appendChild(div);
+document.getElementById("txtFileName").value = newFileName;
+OnLoadFile();
+highlightActiveFile(div);
+addFileModal.style.display = "none";
+modalNewFileNameInput.value = "";
+}
+});
 });
 document.getElementById("clearConsoleBtn").addEventListener("click", () => {
 	consoleOutput.value = "";
 	appendToConsole("Console cleared.", "INFO");
 });
-const outputResizer = document.getElementById("outputResizer");
-const outputWindow = document.getElementById("outputWindow");
-let initialOutputHeight, initialMouseY;
+	const outputResizer = document.getElementById("outputResizer");
+	const outputWindow = document.getElementById("outputWindow");
+	let initialOutputHeight, initialMouseY;
+AdjustWindowSizes();
 outputResizer.addEventListener("mousedown", (e) => {
 	e.preventDefault();
 	initialOutputHeight = outputWindow.offsetHeight;
@@ -513,7 +1074,7 @@ outputResizer.addEventListener("mousedown", (e) => {
 	document.addEventListener("mousemove", resizeOutput);
 	document.addEventListener("mouseup", stopResizeOutput);
 });
-function resizeOutput(e) {
+	function resizeOutput(e) {
 	const deltaY = e.clientY - initialMouseY;
 	let newHeight = initialOutputHeight - deltaY;
 	const minHeight = 100,
@@ -521,11 +1082,11 @@ function resizeOutput(e) {
 	newHeight = Math.max(minHeight, Math.min(newHeight, maxHeight));
 	outputWindow.style.height = `${newHeight}px`;
 }
-function stopResizeOutput() {
+	function stopResizeOutput() {
 	document.removeEventListener("mousemove", resizeOutput);
 	document.removeEventListener("mouseup", stopResizeOutput);
 }
-const rightPanel = document.getElementById("rightPanel");
+	const rightPanel = document.getElementById("rightPanel");
 document
 	.getElementById("menuToggleSolutionExplorer")
 	.addEventListener("click", () => {
@@ -537,32 +1098,64 @@ document
 		);
 	});
 document
-	.getElementById("menuToggleOutputWindow")
-	.addEventListener("click", () => {
-		const isHidden = outputWindow.style.display === "none";
-		outputWindow.style.display = isHidden ? "flex" : "none";
-		outputResizer.style.display = isHidden ? "block" : "none";
-		appendToConsole(
-			`Output Panel ${isHidden ? "shown" : "hidden"}.`,
-			"DEBUG",
-		);
-	});
+        .getElementById("menuToggleOutputWindow")
+        .addEventListener("click", () => {
+	const isHidden = outputWindow.style.display === "none";
+                outputWindow.style.display = isHidden ? "flex" : "none";
+                outputResizer.style.display = isHidden ? "block" : "none";
+	appendToConsole(
+                        `Output Panel ${isHidden ? "shown" : "hidden"}.`,
+                        "DEBUG",
+                );
+        });
 
-appendToConsole("Welcome to the SemDB IDE Console!", "LOG");
-appendToConsole("help", "CMD");
-appendToConsole(
+	if (btnMaximize) btnMaximize.addEventListener("click", OnMaximize);
+	if (btnHalfize) btnHalfize.addEventListener("click", OnHalfize);
+	if (btnMinimize) btnMinimize.addEventListener("click", OnMinimize);
+
+document.addEventListener("keydown", (e) => {
+	if (e.ctrlKey && e.key === ",") {
+	e.preventDefault();
+	startSymbolSearch();
+	} else if (e.ctrlKey && (e.key === "p" || e.key === "P")) {
+	e.preventDefault();
+	startProjectSearch();
+	}
+	});
+	
+	appendToConsole("Welcome to the SemDB IDE Console!", "LOG");
+	appendToConsole("help", "CMD");
+	appendToConsole(
 	"Available: help, clear, run_script, get_active_file",
 	"RESULT",
 );
-appendToConsole("get_active_file", "CMD");
-if (firstFileDivToLoad) {
+	appendToConsole("get_active_file", "CMD");
+	if (firstFileDivToLoad) {
 	appendToConsole(`Active file: ${firstFileDivToLoad.textContent}`, "RESULT");
 }
 
-appendToConsole("SemDB IDE Initialized (Unified Console).", "INFO");
-if (initialFiles.length === 0 && !firstFileDivToLoad) {
+	appendToConsole("SemDB IDE Initialized (Unified Console).", "INFO");
+	if (initialFiles.length === 0 && !firstFileDivToLoad) {
 	appendToConsole(
-		"No project loaded. Use File > Load Project or File > Add File.",
-		"INFO",
-	);
+                "No project loaded. Use File > Load Project or File > Add File.",
+                "INFO",
+        );
 }
+
+window.addEventListener("load", async () => {
+	if (LocalSettings.Solution) {
+document.getElementById("txtSolution").value = LocalSettings.Solution;
+await OnLoadProject();
+	if (LocalSettings.File) {
+document.getElementById("txtFileName").value = LocalSettings.File;
+await OnLoadFile();
+	const item = Array.from(fileList.querySelectorAll('.file-item')).find(d => d.title && d.title.toLowerCase() === LocalSettings.File.toLowerCase());
+	if (item) highlightActiveFile(item);
+}
+}
+});
+
+window.addEventListener("beforeunload", (e) => {
+saveLocalSettings();
+	if (!isCurrentFileSaved()) e.returnValue = "Unsaved changes";
+});


### PR DESCRIPTION
## Summary
- hook CodeMirror gutter for errors
- add ProtoScript workbench styles
- implement `CompileCode` and error highlighting logic
- add command execution and tagging with history tracking
- persist editor settings and add window size controls
- extend CodeMirror with custom hints, prediction shortcuts, breakpoint gutters, and autocomplete

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd88f158832d8e93a58b24fb7593