### PR TITLE
Fix exception rethrow pattern

### DIFF
--- a/Ontology/NativeValuePrototype.cs
+++ b/Ontology/NativeValuePrototype.cs
@@ -455,7 +455,7 @@ namespace Ontology
 					prototype = null;
 
 				else
-					throw err;
+throw;
 			}
 
 			return prototype;

--- a/ProtoScript.Interpretter/Compiler.cs
+++ b/ProtoScript.Interpretter/Compiler.cs
@@ -511,7 +511,7 @@ import Ontology.Simulation Ontology.Simulation.BoolWrapper Boolean;
 				Parsers.ProtoScriptParsingException ex = new Parsers.ProtoScriptParsingException("", 0, "");
 				ex.Explanation = "File does not exist: " + err.Message;
 				ex.File = strFile;
-				throw ex;
+throw;
 			}
 		}
 

--- a/ProtoScript.Interpretter/DebuggingInterpretter.cs
+++ b/ProtoScript.Interpretter/DebuggingInterpretter.cs
@@ -82,7 +82,7 @@ namespace ProtoScript.Interpretter
 					BlockedOn = statement.Info;
 					Wait();
 				}
-				throw err;
+throw;
 			}
 		}
 

--- a/ProtoScript.Interpretter/NativeInterpretter.cs
+++ b/ProtoScript.Interpretter/NativeInterpretter.cs
@@ -331,7 +331,7 @@ namespace ProtoScript.Interpretter
 					}
 				}
 				
-				throw err;
+throw;
 			}
 		}
 
@@ -1601,7 +1601,7 @@ namespace ProtoScript.Interpretter
 				if (err.Message == "Parameter is null")
 					err.Info = lstParameters[err.Info.StartingOffset].Info;
 
-				throw err;
+throw;
 			}
 		}
 

--- a/ProtoScript.Parsers/AnnotationExpressions.cs
+++ b/ProtoScript.Parsers/AnnotationExpressions.cs
@@ -29,7 +29,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 			result.Info.StopStatement(tok.getCursor());

--- a/ProtoScript.Parsers/ExpressionStatements.cs
+++ b/ProtoScript.Parsers/ExpressionStatements.cs
@@ -19,7 +19,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}

--- a/ProtoScript.Parsers/Expressions.cs
+++ b/ProtoScript.Parsers/Expressions.cs
@@ -244,7 +244,7 @@ namespace ProtoScript.Parsers
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}
@@ -548,7 +548,7 @@ namespace ProtoScript.Parsers
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true; 
 			}

--- a/ProtoScript.Parsers/ForEachStatements.cs
+++ b/ProtoScript.Parsers/ForEachStatements.cs
@@ -35,7 +35,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 			result.Info.StopStatement(tok.getCursor());

--- a/ProtoScript.Parsers/ForStatements.cs
+++ b/ProtoScript.Parsers/ForStatements.cs
@@ -54,7 +54,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 

--- a/ProtoScript.Parsers/Identifiers.cs
+++ b/ProtoScript.Parsers/Identifiers.cs
@@ -113,7 +113,7 @@ namespace ProtoScript.Parsers
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 				
 			return strTok.ToString();

--- a/ProtoScript.Parsers/IfStatements.cs
+++ b/ProtoScript.Parsers/IfStatements.cs
@@ -42,7 +42,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}

--- a/ProtoScript.Parsers/MethodDefinitions.cs
+++ b/ProtoScript.Parsers/MethodDefinitions.cs
@@ -260,7 +260,7 @@
 					return lstStatements;
 				}
 
-				throw err;
+throw;
 			}
 
 			method.Info.StopStatement(tok.getCursor());

--- a/ProtoScript.Parsers/PrototypeInitializers.cs
+++ b/ProtoScript.Parsers/PrototypeInitializers.cs
@@ -25,7 +25,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 			result.Info.StopStatement(tok.getCursor());

--- a/ProtoScript.Parsers/ReturnStatements.cs
+++ b/ProtoScript.Parsers/ReturnStatements.cs
@@ -29,7 +29,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 			result.Info.StopStatement(tok.getCursor());

--- a/ProtoScript.Parsers/ScopedExpressionLists.cs
+++ b/ProtoScript.Parsers/ScopedExpressionLists.cs
@@ -31,7 +31,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}

--- a/ProtoScript.Parsers/ThrowStatements.cs
+++ b/ProtoScript.Parsers/ThrowStatements.cs
@@ -25,7 +25,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 			}
 
 

--- a/ProtoScript.Parsers/VariableDeclarations.cs
+++ b/ProtoScript.Parsers/VariableDeclarations.cs
@@ -53,7 +53,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}
@@ -115,7 +115,7 @@
 			catch (Exception err)
 			{
 				if (!Settings.BestCaseExpressions)
-					throw err;
+throw;
 
 				result.Info.IsIncomplete = true;
 			}


### PR DESCRIPTION
## Summary
- use `throw;` instead of `throw ex;` or `throw err;` when rethrowing exceptions

## Testing
- `dotnet test Ontology/Ontology8.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_684c811419b4832d9aef1d8278fbf70c