### PR TITLE
Fix kScripts path in workflow

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -61,7 +61,7 @@ jobs:
           /p:PublishTrimmed=false
 
     - run: |
-        xcopy $env:PROJECT\kScripts $env:ART_ROOT\publish\kScripts /E /I /Y
+        xcopy $env:PROJECT\wwwroot\kScripts $env:ART_ROOT\publish\kScripts /E /I /Y
         if (Test-Path "$env:ART_ROOT\publish\appsettings.Development.json") {
             Remove-Item "$env:ART_ROOT\publish\appsettings.Development.json"
         }

--- a/Scripts/build_deployment_portal.bat
+++ b/Scripts/build_deployment_portal.bat
@@ -22,7 +22,7 @@ dotnet publish -c Release %SOURCE_DIR% -o %DEPLOY_DIR%Site
 
 :kScripts
 
-xcopy /y /e "%SOURCE_DIR%\kScripts\*.*" "%DEPLOY_DIR%Site\kScripts\"
+xcopy /y /e "%SOURCE_DIR%\wwwroot\kScripts\*.*" "%DEPLOY_DIR%Site\kScripts\"
 
 ren "%DEPLOY_DIR%Site\appsettings.json"  "appsettings.json.back"
 


### PR DESCRIPTION
## Summary
- copy `kScripts` from new `wwwroot` location
- update build script with new path

## Testing
- `dotnet restore Ontology/Ontology8.sln`
- `dotnet build Ontology/Ontology8.sln -c Release --no-restore`
- `dotnet test Ontology/Ontology8.sln -c Release --no-build --filter "Category!=Integration"`

------
https://chatgpt.com/codex/tasks/task_e_684f0aac1aac832d81d9fc83cd1e35f9