### PR TITLE
Fix chat tab initialization

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
+++ b/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
@@ -263,16 +263,20 @@
 	}
 
 	Page.AddOnload(x => {
-
-		let txtChatInput = _$('txtChatInput');
-		txtChatInput.addEventListener('keydown', function (event) {
-			if (event.ctrlKey && event.key === 'Enter') {
-				OnChatSend();
-			}
-		});
-
-		Page.Tabs["divTabIconsChat"] = {};
-		Page.Tabs["divTabIconsOriginal"] = {};
+	
+	let txtChatInput = _$("txtChatInput");
+	txtChatInput.addEventListener('keydown', function (event) {
+	if (event.ctrlKey && event.key === 'Enter') {
+	OnChatSend();
+	}
+	});
+	
+	if (!Page.Tabs) {
+	Page.Tabs = {};
+	}
+	
+	Page.Tabs["divTabIconsChat"] = {};
+	Page.Tabs["divTabIconsOriginal"] = {};
 
 		//> add OnLoad functions for each tab to show themself and hide the other
 		Page.Tabs['divTabIconsOriginal'].OnLoad = function () {


### PR DESCRIPTION
## Summary
- ensure Page.Tabs exists before assigning chat tab handlers

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj` *(fails: copy not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516ed55ef0832d90a6ae7754c36ce7