### PR TITLE
Add recent file tab and update editor title

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/Editor.html
+++ b/Buffaly.Ontology.Portal/wwwroot/Editor.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>SemDB IDE</title>
+<title>ProtoScript Editor</title>
 
 	<!-- Tailwind for modern styling -->
 	<script src="https://cdn.tailwindcss.com"></script>
@@ -118,7 +118,7 @@
 	<div class="flex-grow flex p-1 gap-1 overflow-hidden">
 		<!-- Center code editor section -->
 		<section class="flex-grow flex flex-col bg-white p-1 rounded-md shadow border border-gray-200 min-w-0">
-			<textarea id="codeEditor">// Welcome to SemDB IDE! // Load a project or add a file to start.</textarea>
+<textarea id="codeEditor">// Welcome to ProtoScript Editor! // Load a project or add a file to start.</textarea>
 			<input type="text" id="txtFileName" class="hidden">
 		</section>
 
@@ -127,25 +127,31 @@
 				<button data-pane="right" data-tab="tab-solution" class="tab-button right-tab-button active">
 					Solution Explorer
 				</button>
-				<button data-pane="right" data-tab="tab-symbols" class="tab-button right-tab-button">
-					Symbols
+				<button data-pane="right" data-tab="tab-history" class="tab-button right-tab-button">
+					Recent Files
 				</button>
+					<button data-pane="right" data-tab="tab-symbols" class="tab-button right-tab-button">
+				Symbols
+					</button>
 			</div>
 
-			<!-- Solution Explorer tab -->
-			<div id="tab-solution" class="tab-content right-tab-content active flex flex-col flex-grow gap-2 overflow-hidden">
-				<input type="search"
-					   id="txtProjectFileSearch"
-					   placeholder="Search files..."
-					   class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500" />
-				<div id="divProject" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+<!-- Solution Explorer tab -->
+<div id="tab-solution" class="tab-content right-tab-content active flex flex-col flex-grow gap-2 overflow-hidden">
+<input type="search"
+id="txtProjectFileSearch"
+placeholder="Search files..."
+class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500" />
+<div id="divProject" class="flex-grow overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+</div>
 
-				<input type="search"
-					   id="txtFileSearch"
-					   placeholder="Search recent files..."
-					   class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500" />
-				<div id="divSolution" class="overflow-y-auto text-xs space-y-0.5 pr-1"></div>
-			</div>
+<!-- Recent files tab -->
+<div id="tab-history" class="tab-content right-tab-content flex flex-col flex-grow gap-2 overflow-hidden">
+<input type="search"
+id="txtFileSearch"
+placeholder="Search recent files..."
+class="w-full bg-gray-50 border border-gray-300 rounded-md px-2 py-1 text-xs focus:ring-blue-500 focus:border-blue-500" />
+<div id="divSolution" class="overflow-y-auto text-xs space-y-0.5 pr-1"></div>
+</div>
 
 			<!-- Symbols tab -->
 			<div id="tab-symbols" class="tab-content right-tab-content flex flex-col flex-grow gap-2 overflow-hidden">

--- a/Buffaly.Ontology.Portal/wwwroot/js/editor.js
+++ b/Buffaly.Ontology.Portal/wwwroot/js/editor.js
@@ -54,8 +54,8 @@ let currentFileSymbols = [];
 // Initialization
 // ───────────────────────────────────────────────────────────
 function updateTitle() {
-	document.title = `SemDB IDE - ${currentProjectName}`;
-	headerProjectName.textContent = `- ${currentProjectName}`;
+        document.title = `ProtoScript Editor - ${currentProjectName}`;
+        headerProjectName.textContent = `- ${currentProjectName}`;
 }
 updateTitle();
 
@@ -103,12 +103,15 @@ function addFileToHistory(file) {
 }
 
 function bindFileHistory() {
-	if (!divSolution) return;
-	divSolution.innerHTML = "";
-	LocalSettings.FileHistory.forEach(item => {
-		const div = createFileItem(item.File);
-		divSolution.appendChild(div);
-	});
+        if (!divSolution) return;
+        divSolution.innerHTML = "";
+        const root = LocalSettings.Solution
+                ? LocalSettings.Solution.substring(0, LocalSettings.Solution.lastIndexOf("\\"))
+                : "";
+        LocalSettings.FileHistory.forEach(item => {
+                const div = createFileItem(item.File, getRelativePath(root, item.File));
+                divSolution.appendChild(div);
+        });
 }
 
 function bindImmediateHistory() {
@@ -342,7 +345,7 @@ document.querySelectorAll(".tab-button")
 		);
 	}));
 
-switchTab("right", "solutionExplorerTab");
+switchTab("right", "tab-solution");
 switchTab("bottom", "consoleContent");
 
 // ───────────────────────────────────────────────────────────
@@ -636,9 +639,9 @@ function NavigateTo(info, symbolName) {
 // Searches & navigation via keyboard
 // ───────────────────────────────────────────────────────────
 function startSymbolSearch() {
-	switchTab("right", "symbolsTab");
-	searchSymbolsInput.value = "";
-	searchSymbolsInput.focus();
+        switchTab("right", "tab-symbols");
+        searchSymbolsInput.value = "";
+        searchSymbolsInput.focus();
 }
 
 function selectNextSymbol() {
@@ -665,10 +668,10 @@ function navigateToSelectedSymbol() {
 }
 
 function startProjectSearch() {
-	switchTab("right", "solutionExplorerTab");
-	searchFilesInput.value = "";
-	filterProjectFiles();
-	searchFilesInput.focus();
+        switchTab("right", "tab-solution");
+        searchFilesInput.value = "";
+        filterProjectFiles();
+        searchFilesInput.focus();
 }
 function selectNextProjectFile() {
 	if (selectedProjectFileIdx < filteredProjectFiles.length - 1) selectedProjectFileIdx++;


### PR DESCRIPTION
## Summary
- rename page title to ProtoScript Editor
- show relative paths in recent files
- add Recent Files tab in the editor panel
- fix tab switching logic

## Testing
- `dotnet test --no-build` *(fails: MSBUILD error)*

------
https://chatgpt.com/codex/tasks/task_e_6852c591d304832db94a7dcbeabc001e