### PR TITLE
Hide layout elements on TestGraph page

### DIFF
--- a/Buffaly.Ontology.Portal/Pages/TestGraph.cshtml
+++ b/Buffaly.Ontology.Portal/Pages/TestGraph.cshtml
@@ -27,6 +27,12 @@ width: 100%;
 padding: 0;
 height: 100vh;
 }
+#topbar, #divPageTitle, #sidebar {
+display: none;
+}
+.content-page, .content, .container-fluid {
+padding: 0;
+}
 </style>
 <script type="text/javascript" src="JsonWs/ProtoScript.Extensions.ProtoScriptWorkbench.ashx.js"></script>
 }


### PR DESCRIPTION
## Summary
- hide breadcrumbs, title, sidebar and topbar on TestGraph

## Testing
- `dotnet test --no-build -v n` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_6852c7c40520832d9bc80ee4968dc464