### PR TITLE
Restrict CI workflow to main

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -2,9 +2,9 @@ name: Build-Test-Package
 
 on:
   push:
-    branches: [ main, develop, furnari_dev, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop, furnari_dev, master ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- ensure build-test-package workflow only runs for pushes and pull requests targeting `main`

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj -v m` *(fails: NETSDK1045 .NET 9.0 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686d07b83b24832d8ff27412a9835da4