### PR TITLE
Fix nullable types from FirstOrDefault

### DIFF
--- a/Buffaly.NLU.Tagger/RolloutController/ControllerNode.cs
+++ b/Buffaly.NLU.Tagger/RolloutController/ControllerNode.cs
@@ -57,7 +57,7 @@ namespace Buffaly.NLU.Tagger
 		public ControllerNode AddPossibility(ControllerNode node)
 		{
 			//TODO: Implement EqualTo for the BaseNode
-			ControllerNode nodeExisting = this.Possibilities.FirstOrDefault(x => x == node);
+ControllerNode? nodeExisting = this.Possibilities.FirstOrDefault(x => x == node);
 			if (null == nodeExisting)
 			{
 				this.Possibilities.Add(node);
@@ -127,7 +127,7 @@ namespace Buffaly.NLU.Tagger
 		public ControllerNode SelectNextPossibility()
 		{
 			//no random
-			ControllerNode node = this.Possibilities.OrderByDescending(x => x.CurrentValue).FirstOrDefault();
+ControllerNode? node = this.Possibilities.OrderByDescending(x => x.CurrentValue).FirstOrDefault();
 			if (node == null)
 				return null;
 

--- a/Buffaly.NLU/LexemeUtil.cs
+++ b/Buffaly.NLU/LexemeUtil.cs
@@ -93,7 +93,7 @@ namespace Buffaly.NLU
 			if (null == lexeme || lexeme.LexemePrototypes.Count == 0)
 				return null;
 
-			Prototype protoRelated = lexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "BaseObject")).Key;
+			Prototype? protoRelated = lexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "BaseObject")).Key;
 
 			if (null == protoRelated)
 				protoRelated = lexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "Token")).Key;
@@ -115,7 +115,7 @@ namespace Buffaly.NLU
 		//>Consolidate the two previous methods by extracting a common third method taking rowLexeme
 		public static Prototype GetRelatedEntityAsObjectOrTokenOrDefault(TemporaryLexeme rowLexeme)
 		{
-			Prototype protoRelated = rowLexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "BaseObject")).Key;
+			Prototype? protoRelated = rowLexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "BaseObject")).Key;
 
 			if (null == protoRelated)
 				protoRelated = rowLexeme.LexemePrototypes.FirstOrDefault(x => Prototypes.TypeOf(x.Key, "Token")).Key;

--- a/Ontology.Simulation/Sockets.cs
+++ b/Ontology.Simulation/Sockets.cs
@@ -33,7 +33,7 @@
 
 		public void Respond(int iMessageID, Prototype prototype)
 		{
-			Message message = null;
+			Message? message = null;
 
 			lock (m_Lock)
 			{

--- a/ProtoScript.Extensions/CodeContext.cs
+++ b/ProtoScript.Extensions/CodeContext.cs
@@ -82,7 +82,7 @@ namespace ProtoScript.Extensions
 			//symbols.EnterScope(this.CSharpFile.Scope);
 			List<ProtoScript.Statement> lstStatements = new List<Statement>();
 
-			ProtoScript.File file = this.Compiler.Files.FirstOrDefault(x => StringUtil.EqualNoCase(x.Info.FullName, this.ProtoScriptFile.FileName));
+			ProtoScript.File? file = this.Compiler.Files.FirstOrDefault(x => StringUtil.EqualNoCase(x.Info.FullName, this.ProtoScriptFile.FileName));
 			if (null == file)
 			{
 				Logs.DebugLog.WriteEvent("Compiled File Not Found", this.ProtoScriptFile.FileName);

--- a/ProtoScript.Extensions/ContextUtil.cs
+++ b/ProtoScript.Extensions/ContextUtil.cs
@@ -220,7 +220,7 @@ namespace ProtoScript.Extensions
 		{
 			List<Statement> lstContext = new List<Statement>();
 
-			PrototypeDefinition prototypeDefinition = file.PrototypeDefinitions.FirstOrDefault(x => x.Info.IsInside(iOffset));
+			PrototypeDefinition? prototypeDefinition = file.PrototypeDefinitions.FirstOrDefault(x => x.Info.IsInside(iOffset));
 
 			if (null != prototypeDefinition)
 			{
@@ -229,7 +229,7 @@ namespace ProtoScript.Extensions
 
 			else
 			{
-				Statement statement = file.Statements.FirstOrDefault(x => x.Info.IsInside(iOffset));
+				Statement? statement = file.Statements.FirstOrDefault(x => x.Info.IsInside(iOffset));
 				if (null != statement)
 				{
 					lstContext = GetContextAtCursor(statement, iOffset);

--- a/ProtoScript.Extensions/ProtoScriptWorkbench.cs
+++ b/ProtoScript.Extensions/ProtoScriptWorkbench.cs
@@ -708,7 +708,7 @@ namespace ProtoScript.Extensions
 			{
 				jsonObject["Iterations"] = session.Tagger.CurrentIterations;
 
-				Buffaly.NLU.Tagger.BaseFunctionNode node2 = session.Tagger.TaggingNode.Possibilities.OrderByDescending(x => x.Value).FirstOrDefault() as Buffaly.NLU.Tagger.BaseFunctionNode;
+				Buffaly.NLU.Tagger.BaseFunctionNode? node2 = session.Tagger.TaggingNode.Possibilities.OrderByDescending(x => x.Value).FirstOrDefault() as Buffaly.NLU.Tagger.BaseFunctionNode;
 
 				if (null != node2 && null != node2.Source)
 					jsonObject["CurrentInterpretation"] = PrototypeLogging.ToFriendlyString(node2.Source).ToString();

--- a/ProtoScript.Extensions/Suggestions/LLMSuggestions.cs
+++ b/ProtoScript.Extensions/Suggestions/LLMSuggestions.cs
@@ -112,7 +112,7 @@ Collection collection = sequence.GetChildren();		//this calls the GetChildren me
 
 ";
 
-			ProtoScript.File file = context.Compiler.Files.FirstOrDefault(x => StringUtil.EqualNoCase(x.Info.FullName, context.ProtoScriptFile.FileName));
+			ProtoScript.File? file = context.Compiler.Files.FirstOrDefault(x => StringUtil.EqualNoCase(x.Info.FullName, context.ProtoScriptFile.FileName));
 			if (null == file)
 			{
 				Logs.DebugLog.WriteEvent("Compiled File Not Found", context.ProtoScriptFile.FileName);

--- a/ProtoScript.Interpretter/NativeInterpretter.cs
+++ b/ProtoScript.Interpretter/NativeInterpretter.cs
@@ -112,7 +112,7 @@ namespace ProtoScript.Interpretter
 			PrototypeTypeInfo ? prototypeTypeInfo = GetPrototypeTypeInfo(prototype);
 			if (null != prototypeTypeInfo)
 			{
-				FunctionRuntimeInfo functionRuntimeInfo = prototypeTypeInfo.Scope.Symbols.FirstOrDefault(x => (x.Value is FunctionRuntimeInfo && (x.Value as FunctionRuntimeInfo).IsConstructor)).Value as FunctionRuntimeInfo;
+FunctionRuntimeInfo? functionRuntimeInfo = prototypeTypeInfo.Scope.Symbols.FirstOrDefault(x => (x.Value is FunctionRuntimeInfo && (x.Value as FunctionRuntimeInfo).IsConstructor)).Value as FunctionRuntimeInfo;
 				return functionRuntimeInfo;
 			}
 
@@ -126,7 +126,7 @@ namespace ProtoScript.Interpretter
 			PrototypeTypeInfo? prototypeTypeInfo = GetPrototypeTypeInfo(prototype);
 			if (null != prototypeTypeInfo)
 			{
-				FunctionRuntimeInfo functionRuntimeInfo = prototypeTypeInfo.Scope.Symbols.FirstOrDefault(x => (x.Value is FunctionRuntimeInfo && (x.Value as FunctionRuntimeInfo).IsConstructor)).Value as FunctionRuntimeInfo;
+FunctionRuntimeInfo? functionRuntimeInfo = prototypeTypeInfo.Scope.Symbols.FirstOrDefault(x => (x.Value is FunctionRuntimeInfo && (x.Value as FunctionRuntimeInfo).IsConstructor)).Value as FunctionRuntimeInfo;
 				if (null != functionRuntimeInfo)
 				{
 					RunConstructor(functionRuntimeInfo, new List<Compiled.Expression>(), protoThis);
@@ -322,7 +322,7 @@ namespace ProtoScript.Interpretter
 
 				if (null != statement.Info)
 				{
-					File file = this.Compiler.Files.FirstOrDefault(x => x.Info?.FullName == statement.Info?.File);
+File? file = this.Compiler.Files.FirstOrDefault(x => x.Info?.FullName == statement.Info?.File);
 					if (null != file)
 					{
 						string strStatement = file.RawCode.Substring(statement.Info.StartingOffset, statement.Info.Length);


### PR DESCRIPTION
## Summary
- fix improper assignments from FirstOrDefault returning nullable values
- make variables nullable in several modules

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj -v minimal` *(fails: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686d0792bfc0832db1e38957f1b1dd33