### PR TITLE
feat: align project load with directory input

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
+++ b/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
@@ -65,21 +65,18 @@
         </div>
         <%}%>
 
-        <%oSolution.Content{%>
-        <div class="mb-3">
-            <label for="txtSolution" class="form-label">Project</label>
-            
-			<input type="text" kcs:FieldName="Directory" id="txtSolution" class="form-control" />
-
-			<h6 class="fw-bold mt-3">Recent</h6>
-            <div  class="" id="divSolutionHistory"></div>
-			
-			<div class="mt-3" id="divSolutionExamples"></div>
-        </div>
-        <div class="mb-3">
-            <button class="btn btn-primary" onclick="OnLoadProject()">Load Project</button>
-        </div>
-        <%}%>
+		<%oSolution.Content{%>
+		<div class="mb-3">
+		    <label for="txtSolution" class="form-label">Project</label>
+		    <div class="input-group">
+		        <input type="text" kcs:FieldName="Directory" id="txtSolution" class="form-control" />
+		        <button class="btn btn-primary" onclick="OnLoadProject()">Load Project</button>
+		    </div>
+		    <h6 class="fw-bold mt-3">Recent</h6>
+		    <div  class="" id="divSolutionHistory"></div>
+		    <div class="mt-3" id="divSolutionExamples"></div>
+		</div>
+		<%}%>
         <%SimplePage.GetTabs(oTopTabs)%>
     </div>
     <div class="col-lg-3 border">


### PR DESCRIPTION
## Summary
- place the Load Project button on the same row as the project directory textbox

## Testing
- `/root/.dotnet/dotnet test Ontology.Tests/Ontology.Tests.csproj` *(fails: copy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c9973de8832d84128f4ff013e1c1