### PR TITLE
Limit workflow to manual trigger

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,11 +1,7 @@
 name: Build-Test-Package
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
+	workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- restrict build-test-package workflow to manual runs

## Testing
- `dotnet test Ontology/Ontology8.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895d29d78e0832da7b370b82429dedb