### PR TITLE
Improve constructor resolution for ProtoScript

### DIFF
--- a/ProtoScript.Interpretter/Compiler.cs
+++ b/ProtoScript.Interpretter/Compiler.cs
@@ -1808,7 +1808,7 @@ import Ontology.Simulation Ontology.Simulation.BoolWrapper Boolean;
 
 				List<System.Type> lstParameterTypes = lstParams.Select(x => x.InferredType.Type).ToList();
 
-				System.Reflection.ConstructorInfo constructor = type.GetConstructor(lstParameterTypes.ToArray());
+				System.Reflection.ConstructorInfo? constructor = ReflectionUtil.GetConstructor(type, lstParameterTypes);
 
 				if (null == constructor)
 				{


### PR DESCRIPTION
## Summary
- add constructor enumeration and overload resolution helpers
- use ReflectionUtil.GetConstructor when compiling object creation

## Testing
- `dotnet build ProtoScript.Interpretter/ProtoScript.Interpretter.csproj` *(fails: copy: not found)*
- `dotnet test Ontology/Ontology8.sln` *(fails: copy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb2bb768832d80e434b0c7d37680