### PR TITLE
Enable linkable output in ProtoScript workbench

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
+++ b/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
@@ -191,9 +191,9 @@
 				</div>
 				<div class="mt-2 text-end">
 					<a class="me-2" href="javascript:ClearOutput()">Clear</a>
-					<textarea id="txtResults2" class="form-control no-autosize tabstop mt-2" style="font-family: monospace; min-height: 80px; white-space: pre;"></textarea>
-				</div>
-			</div>
+					<div id="txtResults2" class="form-control no-autosize tabstop mt-2" style="font-family: monospace; min-height: 80px; white-space: pre; overflow-y: auto;"></div>
+</div>
+</div>
 
 			<!-- CHAT TAB -->
 			<div class="tab-pane fade h-100" id="chatTab" role="tabpanel" aria-labelledby="chatTab-tab">


### PR DESCRIPTION
## Summary
- Replace plain results textarea with a styled div for console output
- Build output lines as DOM nodes with optional links to navigate to file positions
- Pass file/offset info to `Output` for compile and runtime errors

## Testing
- `dotnet test Ontology/Ontology8.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895edfc55d4832db46049a1cfc16e2b