### PR TITLE
Ensure Immediate window reserves space in workbench

### DIFF
--- a/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
+++ b/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.Controls.ks.html
@@ -327,7 +327,8 @@
 		_$("btnMinimize").removeClass("hidden");
 		_$("btnMaximize").addClass("hidden");
 		Page.LocalSettings.WindowSize = 'Maximize';
-	}
+		AdjustLayout();
+}
 	function OnHalfize() {
 		let iSize = (window.innerHeight / 4 - 115) + "px";
 
@@ -342,7 +343,8 @@
 		_$("divSymbolContainer").style.height = (window.innerHeight / 2 - 65) + "px";
 
 		Page.LocalSettings.WindowSize = 'Halfize';
-	}
+		AdjustLayout();
+}
 	function OnMinimize() {
 		_$("txtImmediate").setStyle('height', '50px');
 		_$("divImmediate").setStyle('height', '250px')
@@ -356,17 +358,19 @@
 
 		ControlUtil.SetValue("chkSaveVerification", false);
 		Page.LocalSettings.WindowSize = 'Minimize'
-	}
+		AdjustLayout();
+}
 
 	function AdjustWindowSizes() {
 		let sWindowSize = Page.LocalSettings.WindowSize;
 		if (sWindowSize == 'Maximize')
-			OnMaximize();
+		OnMaximize();
 		if (sWindowSize == 'Minimize')
-			OnMinimize();
+		OnMinimize();
 		if (sWindowSize == 'Halfize')
-			OnHalfize();
-	}
+		OnHalfize();
+		AdjustLayout();
+}
 </script>
 				<%})
 			})

--- a/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
+++ b/Buffaly.Ontology.Portal/wwwroot/kScripts/ProtoScriptWorkbench/ProtoScript.Workbench.ks.html
@@ -16,7 +16,7 @@
 	}
 </style>
         <%})
-}%>
+	}%>
 
 <%redefinefunction SimplePage.Title
 {
@@ -55,7 +55,7 @@
 
 
 
-<div id="divDirective" class="position-relative" style="height:100vh; padding-right:300px;">
+<div id="divDirective" class="position-relative" style="height:calc(100vh - 250px); padding-right:300px;">
 <div id="divWorkbenchContent" class="h-100 overflow-auto">
 <%oFile.Content{%>
 <div id="divFileContent">
@@ -177,9 +177,17 @@
 
 
 <script type="text/javascript">
+	function AdjustLayout() {
+		let oDirective = _$("divDirective");
+		let oImmediate = _$("divImmediate");
+		if (oDirective && oImmediate)
+			oDirective.style.height = (window.innerHeight - oImmediate.offsetHeight) + "px";
+}
+	window.addEventListener('resize', AdjustLayout);
+	window.addEventListener('load', AdjustLayout);
 	function isLetter(str) {
 		return str.length === 1 && str.match(/[a-z]/i);
-	}
+}
 
 	function OnPredictNextLine(cm, option) {
 


### PR DESCRIPTION
## Summary
- Prevent workbench panes from sliding under Immediate window
- Recalculate available height whenever Immediate window resizes or viewport changes

## Testing
- `dotnet test Ontology/Ontology8.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68960afd0ef4832d9719e66399bbec93