### PR TITLE
Ensure ParameterRuntimeInfo clone preserves parameter name

### DIFF
--- a/Ontology.Tests/ParameterRuntimeInfo_Tests.cs
+++ b/Ontology.Tests/ParameterRuntimeInfo_Tests.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProtoScript.Interpretter.RuntimeInfo;
+
+namespace Ontology.Tests
+{
+	[TestClass]
+	public sealed class ParameterRuntimeInfo_Tests
+	{
+		[TestMethod]
+		public void Clone_RetainsParameterName()
+		{
+			ParameterRuntimeInfo param = new ParameterRuntimeInfo();
+			param.ParameterName = "foo";
+			ParameterRuntimeInfo clone = (ParameterRuntimeInfo)param.Clone();
+			Assert.AreEqual(param.ParameterName, clone.ParameterName);
+		}
+	}
+}

--- a/ProtoScript.Interpretter/RuntimeInfo/ParameterRuntimeInfo.cs
+++ b/ProtoScript.Interpretter/RuntimeInfo/ParameterRuntimeInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace ProtoScript.Interpretter.RuntimeInfo
+namespace ProtoScript.Interpretter.RuntimeInfo
 {
 	public class ParameterRuntimeInfo : ValueRuntimeInfo
 	{
@@ -10,6 +10,7 @@
 			info.Type = Type;
 			info.OriginalType = OriginalType;
 			info.Value = Value;
+			info.ParameterName = ParameterName;
 			return info;
 		}
 
@@ -17,6 +18,5 @@
 		{
 			return $"ParameterRuntimeInfo:[{Index}] {Type} ({Value})";
 		}
-
 	}
 }


### PR DESCRIPTION
## Summary
- copy ParameterName when cloning ParameterRuntimeInfo instances
- add unit test covering ParameterRuntimeInfo clone behavior

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj --filter Clone_RetainsParameterName` *(fails: The type or namespace name 'Agents' does not exist in the namespace 'Ontology')*


------
https://chatgpt.com/codex/tasks/task_e_689b934a19f4832daa08a69524013e0f