### PR TITLE
Support named-argument method invocation

### DIFF
--- a/ProtoScript.Interpretter/NativeInterpretter.cs
+++ b/ProtoScript.Interpretter/NativeInterpretter.cs
@@ -1678,6 +1678,46 @@ throw;
 			return this.RunMethod(infoFunction, protoInstance, lstParameters);
 		}
 
+		/// <summary>
+		/// Runs a ProtoScript method using named arguments.
+		/// </summary>
+		/// <example>
+		/// IDictionary<string, object> args = new Dictionary<string, object>();
+		/// args["child"] = interpreter.GetLocalPrototype("Bart");
+		/// interpreter.RunMethodAsObject("Homer", "IsParentOf", args);
+		/// </example>
+		public object ? RunMethodAsObject(Prototype ? protoInstance, string strMethodName, IDictionary<string, object> dictParameters)
+		{
+			FunctionRuntimeInfo ? infoFunction = null;
+			
+			if (null == protoInstance)
+			{
+				infoFunction = this.Symbols.GetSymbol(strMethodName) as FunctionRuntimeInfo;
+				if (null == infoFunction)
+				throw new Exception("Could not find global method: " + strMethodName);
+			}
+			
+			else
+			{
+				infoFunction = this.FindOverriddenMethod(protoInstance, strMethodName);
+				
+				if (null == infoFunction)
+				throw new Exception("Could not find method: " + strMethodName + ", on prototype: " + protoInstance.PrototypeName);
+			}
+			
+			List<object> lstParameters = new List<object>();
+			
+			foreach (ParameterRuntimeInfo infoParam in infoFunction.Parameters)
+			{
+				object oValue;
+				if (!dictParameters.TryGetValue(infoParam.ParameterName, out oValue))
+				throw new Exception("Missing parameter: " + infoParam.ParameterName);
+				lstParameters.Add(oValue);
+			}
+			
+			return this.RunMethod(infoFunction, protoInstance, lstParameters);
+		}
+
 		public Prototype ? RunMethodAsPrototype(Prototype protoInstance, string strMethodName, object oParam1)
 		{
 			return RunMethodAsPrototype(protoInstance, strMethodName, new List<object> { oParam1 });

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ namespace SimpsonsOntology
 		function IsParent() : Boolean {
 			return ParentOf.Count > 0;
 		}
+		function HasChild(Person child) : Boolean {
+			return ParentOf.Contains(child);
+		}
 	}
 
 	prototype Bart : Person {
@@ -85,6 +88,13 @@ interpreter.Evaluate(compiled);
 
 bool isParent = (bool)interpreter.RunMethodAsObject("Homer", "IsParent", new List<object>());
 Console.WriteLine($"Homer is a parent? {isParent}");
+
+Dictionary<string, object> namedArgs = new Dictionary<string, object>
+{
+	{ "child", interpreter.GetLocalPrototype("Bart") }
+};
+bool isParentOfBart = (bool)interpreter.RunMethodAsObject("Homer", "HasChild", namedArgs);
+Console.WriteLine($"Homer is Bart's parent? {isParentOfBart}");
 ```
 See the unit tests under **Ontology.Tests** for examples on how to load
 the ontology, query concepts and register custom behaviours.


### PR DESCRIPTION
## Summary
- add NativeInterpretter.RunMethodAsObject overload accepting IDictionary parameters
- document calling methods with named arguments in README

## Testing
- `dotnet test Ontology.Tests/Ontology.Tests.csproj` *(fails: NETSDK1045: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b934e5f60832dbe862a17e053f737